### PR TITLE
fix(deps): pin vanity-address to 0.1.4 (only published version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ asciimatics>=1.15,<2.0
 plotext>=5.2,<6.0
 blessings>=1.7,<2.0
 bitcoinlib>=0.6,<1.0
-vanity-address>=1.0,<2.0
+vanity-address==0.1.4


### PR DESCRIPTION
## Summary

`requirements.txt` pins `vanity-address>=1.0,<2.0` but PyPI only has version **0.1.4**. This breaks `pip install -r requirements.txt` during Docker image builds — blocking the publish of `curly60e/pyblock:v4.0.1` needed for getumbrel/umbrel-apps#5258.

## Verification

- `pip index versions vanity-address` → only `0.1.4` available
- Installed `vanity-address==0.1.4` and verified the import used in `pybitblock/SPV/PyVanityGenerator.py` works: `from vanity_address.vanity_address import VanityAddressGenerator` ✅

## Test plan
- [ ] Maintainer review
- [ ] Rebuild Docker image with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)