### PR TITLE
OracleVision v2.2: Transaction Inspector and pluggable detectors

### DIFF
--- a/PR_ORACLEVISION_V2.2.md
+++ b/PR_ORACLEVISION_V2.2.md
@@ -1,0 +1,174 @@
+# OracleVision v2.2: Transaction Inspector & Pluggable Detectors
+
+## Summary
+
+This PR upgrades PyBLOCK's OracleVision integration from the initial v1 port to **v2.2 analysis parity**, adding deep transaction inspection, address lookup, pluggable BIP-110 detectors, and cross-menu drill-down from block analysis.
+
+All features run locally via `bitcoin-cli` — **Don't Trust, Verify**.
+
+## Motivation
+
+The initial OracleVision integration (PR #738) gave PyBLOCK operators block scanning, Mempool Glass, and block detail views. The standalone [OracleVision](https://github.com/MarcanoFilms/oraculovision) project has since shipped **v2.2** with:
+
+- **Transaction Inspector** — input/output flow, fees, BIP-110 flags, spam signals
+- **Address Inspector** — UTXO balance via `scantxoutset`, mempool exposure
+- **Pluggable detectors** — community-extensible BIP-110 rule checks
+- **Pruned-node support** — partial inspection from block scan cache (`flagged_raw`)
+
+This PR ports those analysis capabilities into PyBLOCK's Rich terminal UI so operators get v2.2 tooling without leaving the PyBLOCK menu.
+
+## What's New
+
+### Menu changes
+
+| Option | Before | After |
+|--------|--------|-------|
+| A | BIP-110 Block Scanner | *(unchanged)* |
+| B | Mempool Glass | *(unchanged, improved docs)* |
+| C | Block Detail View | **+ drill-down to Transaction Inspector** |
+| D | Launch Full TUI | **Transaction & Address Inspector** |
+| E | — | Launch Full OracleVision TUI *(was D)* |
+
+### New module: Transaction & Address Inspector (D)
+
+Dual-mode inspector accepting a **64-char txid** or **Bitcoin address**:
+
+**Transaction mode** shows:
+- Mempool / confirmation status, block height, fees (BTC + sat/vB)
+- Input/output flow with addresses, values, script types
+- Mempool category (economic / spam / coinjoin / consolidation)
+- BIP-110 compliance label and flag list
+- Spam signals (inscription, brc20, runes, ordinals, op_return)
+
+**Address mode** shows:
+- Node validation, script type
+- UTXO balance and count (`scantxoutset`, configurable timeout)
+- Mempool exposure (capped scan of pending outputs)
+
+**Pruned-node handling:**
+- Block Detail caches flagged raw transactions during scan
+- Inspector uses cached data when `getrawtransaction` is unavailable
+- Partial view clearly labeled with yellow border
+
+### Pluggable detectors (`pybitblock/oraclevision/detectors/`)
+
+Refactored `bip110.py` to delegate per-transaction analysis to a detector registry:
+
+| File | Purpose |
+|------|---------|
+| `detectors/__init__.py` | Registry API: `register()`, `run_detectors()`, `configure_detectors()` |
+| `detectors/builtin.py` | Default Knots BIP-110 + spam heuristics (extracted from monolithic bip110) |
+
+Community PRs can add new detectors without touching UI code. Enable via `detectors_enabled` in config.
+
+### New supporting modules
+
+| File | Purpose |
+|------|---------|
+| `tx_flow.py` | Pure I/O parsing: inputs, outputs, fees, senders/recipients |
+| `tx_service.py` | Fetch, enrich, and format transaction inspections |
+| `address_service.py` | Address validation, UTXO scan, mempool exposure |
+| `addresses.py` | Query classification (txid vs address) |
+| `markup.py` | Safe Rich markup escaping for node-sourced text |
+
+### Extended `bitcoin_cli.py`
+
+New RPC wrappers for the inspector:
+- `getrawmempool(verbose)`
+- `getrawtransaction(txid, verbose, block_hash=…)` — pruned-node compatible
+- `getblockchaininfo()`
+- `validateaddress(address)`
+- `scantxoutset_address(address, timeout=…)`
+
+### Block analysis improvements
+
+- `BlockAnalysis.flagged_raw` — caches raw tx dicts for flagged transactions
+- Block Detail prompts for tx drill-down after showing problematic transactions
+- Mempool Glass notes link to Transaction Inspector
+
+## Configuration
+
+New keys in `oraclevision.conf`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `max_vin_lookups` | 4 | Parent tx RPC lookups to resolve missing prevouts |
+| `scantxoutset_timeout` | 90 | Seconds for UTXO scan (address mode) |
+| `mempool_scan_limit` | 30 | Max mempool txs scanned for address exposure |
+| `detectors_enabled` | `["builtin"]` | Active detector plugins |
+
+## Design Principles
+
+- **Zero extra dependencies** — Rich UI + bitcoin-cli only (same as PyBLOCK)
+- **Modular analysis** — detectors, tx_flow, services separated from terminal UI
+- **Upstream alignment** — ported from OracleVision v2.2 analysis layer
+- **Full TUI still external** — option E launches standalone Textual dashboard
+
+## Relationship to Standalone OracleVision
+
+| Feature | PyBLOCK built-in | Full OracleVision TUI |
+|---------|------------------|----------------------|
+| Block scanner | Yes | Yes (+ live charts) |
+| Mempool Glass | Yes | Yes (+ dedicated screen) |
+| Tx Inspector | Yes (Rich terminal) | Yes (Textual, keyboard nav) |
+| Address Inspector | Yes (UTXO + mempool) | Yes (+ history export) |
+| DATUM mining panel | No | Yes |
+| Ocean account stats | No | Yes |
+| Multi-screen navigation | No | Yes |
+
+Operators who want the full dashboard install OracleVision separately and use **E. Launch Full OracleVision TUI**.
+
+## Testing
+
+```bash
+cd pybitblock
+
+# Import check
+python3 -c "from oraclevision.tx_service import TxService; print('ok')"
+
+# Unit tests
+python3 -m pytest tests/oraclevision/ -v
+
+# Manual test path
+python3 PyBlock.py
+# → B. Bitcoin → OV. OracleVision
+#   → D. Transaction & Address Inspector (paste a txid)
+#   → C. Block Detail View → inspect flagged tx
+```
+
+### Node requirements
+
+- Synced Knots/Core with RPC enabled
+- `getblock` verbosity 2 (block scanner, block detail)
+- `getblocktemplate` with mining RPC (Mempool Glass)
+- `getrawtransaction` with optional `blockhash` (tx inspector)
+- `scantxoutset` (address mode — can take up to 90s on large UTXO sets)
+
+## Files Changed
+
+### New
+- `pybitblock/oraclevision/detectors/__init__.py`
+- `pybitblock/oraclevision/detectors/builtin.py`
+- `pybitblock/oraclevision/tx_flow.py`
+- `pybitblock/oraclevision/tx_service.py`
+- `pybitblock/oraclevision/address_service.py`
+- `pybitblock/oraclevision/addresses.py`
+- `pybitblock/oraclevision/markup.py`
+- `pybitblock/tests/oraclevision/test_tx_flow.py`
+- `pybitblock/tests/oraclevision/test_detectors.py`
+- `pybitblock/tests/oraclevision/test_addresses.py`
+- `PR_ORACLEVISION_V2.2.md`
+
+### Modified
+- `pybitblock/oraclevision/bip110.py` — detector architecture + `flagged_raw`
+- `pybitblock/oraclevision/bitcoin_cli.py` — tx/address RPC methods
+- `pybitblock/oraclevision/config.py` — inspector settings + detector config
+- `pybitblock/oraclevision/ui.py` — menu D/E, tx inspector, block drill-down
+- `pybitblock/oraclevision/__init__.py` — new exports
+- `pybitblock/oraclevision/mempool_compose.py` — legacy aliases
+- `pybitblock/config/oraclevision.conf.example`
+- `README.md`
+
+## Upstream
+
+Analysis logic ported from [MarcanoFilms/oraculovision](https://github.com/MarcanoFilms/oraculovision) v2.2.0a1.

--- a/PR_ORACLEVISION_V2.2.md
+++ b/PR_ORACLEVISION_V2.2.md
@@ -38,7 +38,7 @@ Dual-mode inspector accepting a **64-char txid** or **Bitcoin address**:
 - Input/output flow with addresses, values, script types
 - Mempool category (economic / spam / coinjoin / consolidation)
 - BIP-110 compliance label and flag list
-- Spam signals (inscription, brc20, runes, ordinals, op_return)
+- Spam signals (inscription, BRC-20, runes, ordinals, OP_RETURN)
 
 **Address mode** shows:
 - Node validation, script type

--- a/README.md
+++ b/README.md
@@ -281,8 +281,9 @@ PyBLOCK includes a lightweight integration with [OracleVision](https://github.co
 |--------|----------------|
 | **BIP-110 Block Scanner** | Scans recent blocks for consensus violations, spam score (0–100), and status (CLEAN / SUSPICIOUS / VIOLATION) |
 | **Mempool Glass** | Categorizes your node's current `getblocktemplate` into economic, consolidation, coinjoin, and spam buckets |
-| **Block Detail View** | Deep-dive into a single block: miner tag, witness %, violation flags, problematic transactions |
-| **Launch Full OracleVision** | Opens the standalone Textual TUI if installed (DATUM mining, Ocean panels, live charts) |
+| **Block Detail View** | Deep-dive into a single block: miner tag, witness %, violation flags, problematic transactions — with drill-down to Transaction Inspector |
+| **Transaction & Address Inspector** | Inspect any txid (flow, fees, BIP-110 flags, spam signals) or address (UTXO balance, mempool exposure) — verified locally |
+| **Launch Full OracleVision** | Opens the standalone Textual TUI if installed (DATUM mining, Ocean panels, live charts, multi-screen navigation) |
 
 ### Configuration
 
@@ -298,6 +299,10 @@ cp pybitblock/config/oraclevision.conf.example pybitblock/config/oraclevision.co
 | `spam_score_threshold` | 45 | Score above this marks a block as VIOLATION |
 | `bitcoin_datadir` | `""` | Optional `-datadir` for bitcoin-cli |
 | `oraculovision_command` | `oraculovision` | Command to launch the full TUI |
+| `max_vin_lookups` | 4 | Parent-tx RPC lookups to resolve input prevouts in Transaction Inspector |
+| `scantxoutset_timeout` | 90 | Seconds allowed for UTXO scan in Address Inspector |
+| `mempool_scan_limit` | 30 | Max mempool txs scanned for address mempool exposure |
+| `detectors_enabled` | `["builtin"]` | Active BIP-110/spam detector plugins |
 
 Environment overrides: `ORACULOVISION_BLOCK_SCAN_COUNT`, `ORACULOVISION_SPAM_THRESHOLD`, `ORACULOVISION_COMMAND`, `BITCOIN_DATADIR`.
 
@@ -314,18 +319,21 @@ pip install -e .
 oraculovision
 ```
 
-From PyBLOCK, use **Bitcoin → OV. OracleVision → D. Launch Full OracleVision TUI**.
+From PyBLOCK, use **Bitcoin → OV. OracleVision → E. Launch Full OracleVision TUI**.
 
 ### Extending detection logic
 
 The analysis engine lives in `pybitblock/oraclevision/` and is intentionally modular:
 
 - `script_parser.py` — BIP-110 size limits and witness/script parsing
-- `bip110.py` — per-transaction and per-block rule checks
+- `detectors/` — pluggable per-transaction rule checks (register new detectors via config)
+- `bip110.py` — per-block aggregation and spam scoring
 - `spam_score.py` — heuristic scoring (community-tunable weights)
 - `mempool_compose.py` — block template categorization
+- `tx_flow.py` / `tx_service.py` — transaction flow parsing and deep inspection
+- `address_service.py` — UTXO balance and mempool exposure for addresses
 
-Pull requests that improve heuristics or add new violation rules are welcome. Keep UI code in `oraclevision/ui.py` separate from detection logic.
+Pull requests that improve heuristics or add new violation rules are welcome. Add detectors in `oraclevision/detectors/` and keep UI code in `oraclevision/ui.py` separate from detection logic.
 
   
 ## Running PyBLOCK using Docker

--- a/pybitblock/config/oraclevision.conf.example
+++ b/pybitblock/config/oraclevision.conf.example
@@ -3,5 +3,9 @@
   "spam_score_threshold": 45,
   "bitcoin_datadir": "",
   "oraculovision_command": "oraculovision",
-  "cli_timeout_seconds": 60
+  "cli_timeout_seconds": 60,
+  "max_vin_lookups": 4,
+  "scantxoutset_timeout": 90,
+  "mempool_scan_limit": 30,
+  "detectors_enabled": ["builtin"]
 }

--- a/pybitblock/oraclevision/__init__.py
+++ b/pybitblock/oraclevision/__init__.py
@@ -8,15 +8,26 @@ modular so the community can extend heuristics without touching the UI.
 Upstream: https://github.com/MarcanoFilms/oraculovision
 """
 
+from oraclevision.address_service import AddressInspection, AddressService
 from oraclevision.bip110 import BlockAnalysis, TxAnalysis, analyze_block, analyze_transaction
 from oraclevision.mempool_compose import MempoolComposition, analyze_block_template, categorize_transaction
+from oraclevision.tx_flow import TxFlowSummary, TxIO, build_flow_summary
+from oraclevision.tx_service import TxInspectContext, TxInspection, TxService
 
 __all__ = [
+    "AddressInspection",
+    "AddressService",
     "BlockAnalysis",
     "TxAnalysis",
+    "TxFlowSummary",
+    "TxIO",
+    "TxInspectContext",
+    "TxInspection",
+    "TxService",
     "MempoolComposition",
     "analyze_block",
     "analyze_transaction",
     "analyze_block_template",
+    "build_flow_summary",
     "categorize_transaction",
 ]

--- a/pybitblock/oraclevision/address_service.py
+++ b/pybitblock/oraclevision/address_service.py
@@ -1,0 +1,153 @@
+"""Address balance and mempool exposure via the local node."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from oraclevision.addresses import parse_address_query
+from oraclevision.bitcoin_cli import BitcoinCLI, BitcoinCLIError
+from oraclevision.config import InspectorConfig
+
+
+class AddressQueryError(ValueError):
+    """Invalid or unresolvable address query."""
+
+
+@dataclass
+class AddressInspection:
+    address: str
+    valid: bool = False
+    script_type: str = ""
+    balance_btc: float = 0.0
+    utxo_count: int = 0
+    mempool_tx_count: int = 0
+    mempool_pending_btc: float = 0.0
+    scan_seconds: float | None = None
+    error: str | None = None
+
+
+def format_address_inspection(ins: AddressInspection) -> str:
+    lines: list[str] = [
+        f"[bold rgb(255,215,0)]Address[/]  {ins.address}",
+        "",
+    ]
+    if ins.error:
+        lines.append(f"[red]{ins.error}[/]")
+        return "\n".join(lines)
+
+    valid_style = "green" if ins.valid else "red"
+    lines.extend([
+        f"[bold]Valid[/]       [{valid_style}]{'yes' if ins.valid else 'no'}[/]",
+        f"[bold]Type[/]        {ins.script_type or '—'}",
+        f"[bold]UTXO balance[/] {ins.balance_btc:.8f} BTC  ({ins.utxo_count} UTXOs)",
+    ])
+    if ins.scan_seconds is not None:
+        lines.append(f"[bold]Scan time[/]   {ins.scan_seconds:.1f}s  (scantxoutset)")
+    lines.extend([
+        "",
+        f"[bold]Mempool[/]     {ins.mempool_tx_count} pending tx(s)  "
+        f"·  {ins.mempool_pending_btc:.8f} BTC to this address",
+        "",
+        "[dim]Balance is confirmed UTXO set only — not full transaction history.[/]",
+        "[dim]Enter a txid from mempool exposure to inspect in Transaction mode.[/]",
+    ])
+    return "\n".join(lines)
+
+
+class AddressService:
+    """Inspect addresses via validateaddress and scantxoutset."""
+
+    def __init__(
+        self,
+        cli: BitcoinCLI,
+        config: InspectorConfig | None = None,
+    ) -> None:
+        self.cli = cli
+        self.config = config or InspectorConfig()
+
+    def inspect(self, raw_query: str) -> AddressInspection:
+        address = parse_address_query(raw_query)
+        return self.inspect_address(address)
+
+    def inspect_address(self, address: str) -> AddressInspection:
+        result = AddressInspection(address=address)
+
+        try:
+            validation = self.cli.validate_address(address)
+        except BitcoinCLIError as exc:
+            result.error = str(exc)
+            return result
+
+        result.valid = bool(validation.get("isvalid"))
+        spk = validation.get("scriptPubKey")
+        if isinstance(spk, dict):
+            result.script_type = str(spk.get("type", "") or "")
+        elif validation.get("iswitness"):
+            result.script_type = "witness"
+        elif validation.get("isscript"):
+            result.script_type = "script"
+        else:
+            result.script_type = ""
+
+        if not result.valid:
+            result.error = "Address failed node validation"
+            return result
+
+        started = time.monotonic()
+        try:
+            scan = self.cli.scantxoutset_address(
+                address,
+                timeout=self.config.scantxoutset_timeout,
+            )
+            result.scan_seconds = time.monotonic() - started
+            if isinstance(scan, dict):
+                total = scan.get("total_amount")
+                if total is not None:
+                    result.balance_btc = float(total)
+                unspents = scan.get("unspents")
+                if isinstance(unspents, list):
+                    result.utxo_count = len(unspents)
+        except BitcoinCLIError as exc:
+            result.error = f"UTXO scan failed: {exc}"
+            return result
+
+        mempool_tx, mempool_btc = self._scan_mempool_for_address(address)
+        result.mempool_tx_count = mempool_tx
+        result.mempool_pending_btc = mempool_btc
+        return result
+
+    def _scan_mempool_for_address(self, address: str) -> tuple[int, float]:
+        """Best-effort mempool exposure scan (capped RPC calls)."""
+        limit = self.config.mempool_scan_limit
+        try:
+            mempool = self.cli.get_raw_mempool(verbose=False)
+        except BitcoinCLIError:
+            return 0, 0.0
+
+        if not isinstance(mempool, list):
+            return 0, 0.0
+
+        count = 0
+        pending_btc = 0.0
+        for txid in mempool[:limit]:
+            try:
+                tx = self.cli.get_raw_transaction(str(txid), True)
+            except BitcoinCLIError:
+                continue
+            if not isinstance(tx, dict):
+                continue
+            matched = False
+            for vout in tx.get("vout", []):
+                if not isinstance(vout, dict):
+                    continue
+                spk = vout.get("scriptPubKey") or {}
+                addr = spk.get("address")
+                addrs = spk.get("addresses") or []
+                if addr == address or address in addrs:
+                    pending_btc += float(vout.get("value", 0) or 0)
+                    matched = True
+            if matched:
+                count += 1
+        return count, pending_btc

--- a/pybitblock/oraclevision/addresses.py
+++ b/pybitblock/oraclevision/addresses.py
@@ -1,0 +1,39 @@
+"""Bitcoin address and txid query parsing helpers."""
+
+from __future__ import annotations
+
+import re
+
+_TXID_RE = re.compile(r"^[0-9a-f]{64}$")
+_ADDRESS_RE = re.compile(
+    r"^(bc1[a-z0-9]{25,87}|bc1p[a-z0-9]{25,87}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})$"
+)
+
+
+class AddressQueryError(ValueError):
+    """Invalid address query."""
+
+
+def is_txid_query(raw: str) -> bool:
+    return bool(_TXID_RE.fullmatch((raw or "").strip().lower()))
+
+
+def parse_address_query(raw: str) -> str:
+    address = (raw or "").strip()
+    if not address:
+        raise AddressQueryError("Enter a Bitcoin address (bc1…, 1…, or 3…)")
+    if not _ADDRESS_RE.fullmatch(address):
+        raise AddressQueryError(
+            "Invalid address — use bc1…, 1…, or 3… format"
+        )
+    return address
+
+
+def classify_query(raw: str) -> tuple[str, str]:
+    """Return ('txid', value) or ('address', value)."""
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("Empty query")
+    if is_txid_query(text):
+        return "txid", text.lower()
+    return "address", parse_address_query(text)

--- a/pybitblock/oraclevision/bip110.py
+++ b/pybitblock/oraclevision/bip110.py
@@ -2,7 +2,7 @@
 BIP-110 block/transaction analysis engine.
 
 Checks reduced_data policy rules locally against decoded block data.
-Extend _check_witness_rules() and analyze_transaction() for new rules.
+Detection logic is delegated to pluggable detectors in oraclevision/detectors/.
 """
 
 from __future__ import annotations
@@ -10,23 +10,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from oraclevision.detectors import configure_detectors, run_detectors
 from oraclevision.script_parser import (
-    MAX_CONTROL_BLOCK_SIZE,
-    MAX_OPRETURN_SIZE,
     MAX_PUSHDATA_SIZE,
-    MAX_SCRIPTPUBKEY_SIZE,
     decode_coinbase_tag,
-    detect_inscription_in_witness,
-    detect_token_patterns,
-    has_annex,
-    infer_taproot_script_path,
-    is_op_return,
     is_signaling_bip110,
-    is_valid_taproot_control_block,
-    scan_tapscript_violations,
-    script_has_large_push,
-    vout_script_size,
-    witness_total_bytes,
 )
 from oraclevision.spam_score import classify_status, compute_spam_score
 
@@ -69,114 +57,7 @@ class BlockAnalysis:
     large_witness_bytes: int = 0
     witness_pct: float = 0.0
     transactions: list[TxAnalysis] = field(default_factory=list)
-
-
-def _prevout_type(vin: dict) -> str | None:
-    if isinstance(vin.get("prevout"), dict):
-        spk = vin["prevout"].get("scriptPubKey", {})
-        return spk.get("type")
-    return None
-
-
-def _check_witness_rules(vin: dict) -> set[str]:
-    flags: set[str] = set()
-    witness: list[str] = vin.get("txinwitness") or vin.get("witness") or []
-    if not witness:
-        return flags
-
-    annex = has_annex(witness)
-    prevout_type = _prevout_type(vin)
-    is_taproot_prevout = prevout_type == "witness_v1_taproot" or prevout_type == "v1_p2tr"
-    is_script_path = (
-        (is_taproot_prevout and len(witness) > (2 if annex else 1))
-        or infer_taproot_script_path(witness)
-    )
-
-    if annex and (is_taproot_prevout or is_script_path):
-        flags.add("taproot_annex")
-
-    exempt: set[int] = set()
-    executing_scripts: list[int] = []
-
-    if annex:
-        exempt.add(len(witness) - 1)
-
-    if is_script_path:
-        cb_idx = len(witness) - (2 if annex else 1)
-        tap_idx = cb_idx - 1
-        exempt.add(cb_idx)
-        if tap_idx >= 0:
-            exempt.add(tap_idx)
-            executing_scripts.append(tap_idx)
-    elif is_taproot_prevout:
-        sig_idx = len(witness) - 1 - (1 if annex else 0)
-        if sig_idx >= 0:
-            exempt.add(sig_idx)
-    elif prevout_type in ("witness_v0_scripthash", "v0_p2wsh", "scripthash", "p2sh") or prevout_type is None:
-        ws_idx = len(witness) - 1 - (1 if annex else 0)
-        if ws_idx >= 0:
-            exempt.add(ws_idx)
-            executing_scripts.append(ws_idx)
-
-    for i, item in enumerate(witness):
-        if i in exempt:
-            continue
-        if len(item) // 2 > MAX_PUSHDATA_SIZE:
-            flags.add("large_pushdata")
-            break
-
-    if is_script_path:
-        cb_idx = len(witness) - (2 if annex else 1)
-        cb = witness[cb_idx]
-        if len(cb) // 2 > MAX_CONTROL_BLOCK_SIZE:
-            flags.add("large_control_block")
-        if is_valid_taproot_control_block(cb):
-            leaf_version = int(cb[:2], 16) & 0xFE
-            if leaf_version != 0xC0:
-                flags.add("undefined_witness")
-        tap_idx = cb_idx - 1
-        if tap_idx >= 0:
-            tapscript = witness[tap_idx]
-            op_success, op_if = scan_tapscript_violations(tapscript)
-            if op_success:
-                flags.add("op_success")
-            if op_if:
-                flags.add("op_if_notif")
-
-    if "large_pushdata" not in flags:
-        for idx in executing_scripts:
-            if script_has_large_push(witness[idx]):
-                flags.add("large_pushdata")
-                break
-
-    return flags
-
-
-def _check_scriptsig_rules(vin: dict) -> set[str]:
-    flags: set[str] = set()
-    scriptsig = vin.get("scriptSig", {})
-    hex_sig = scriptsig.get("hex", "") if isinstance(scriptsig, dict) else ""
-    if not hex_sig:
-        return flags
-
-    asm = scriptsig.get("asm", "") if isinstance(scriptsig, dict) else ""
-    if asm:
-        parts = asm.split()
-        prevout_type = _prevout_type(vin)
-        redeem_idx = len(parts) - 1 if prevout_type in ("scripthash", "p2sh") else -1
-        for i, part in enumerate(parts):
-            if part.startswith("OP_"):
-                continue
-            if i == redeem_idx:
-                if script_has_large_push(part):
-                    flags.add("large_pushdata")
-                continue
-            if len(part) // 2 > MAX_PUSHDATA_SIZE:
-                flags.add("large_pushdata")
-                break
-    elif script_has_large_push(hex_sig):
-        flags.add("large_pushdata")
-    return flags
+    flagged_raw: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 def analyze_transaction(tx: dict[str, Any]) -> TxAnalysis:
@@ -184,50 +65,15 @@ def analyze_transaction(tx: dict[str, Any]) -> TxAnalysis:
     weight = int(tx.get("weight") or (tx.get("vsize", 0) * 4))
     vsize = int(tx.get("vsize") or weight // 4)
 
-    analysis = TxAnalysis(txid=txid, weight=weight, vsize=vsize)
-    bip110: set[str] = set()
-    signals: set[str] = set()
-
-    for vout in tx.get("vout", []):
-        size = vout_script_size(vout)
-        if is_op_return(vout):
-            signals.add("op_return")
-            if size > MAX_OPRETURN_SIZE:
-                bip110.add("large_scriptpubkey")
-        elif size > MAX_SCRIPTPUBKEY_SIZE:
-            bip110.add("large_scriptpubkey")
-
-    witness_bytes = 0
-    all_hex = txid
-
-    for vin in tx.get("vin", []):
-        if vin.get("coinbase"):
-            continue
-        witness: list[str] = vin.get("txinwitness") or vin.get("witness") or []
-        witness_bytes += witness_total_bytes(witness)
-        all_hex += "".join(witness)
-
-        bip110 |= _check_witness_rules(vin)
-        bip110 |= _check_scriptsig_rules(vin)
-
-        if detect_inscription_in_witness(witness):
-            signals.add("inscription")
-
-        scriptsig = vin.get("scriptSig", {})
-        if isinstance(scriptsig, dict):
-            all_hex += scriptsig.get("hex", "")
-
-    for vout in tx.get("vout", []):
-        spk = vout.get("scriptPubKey", {})
-        all_hex += spk.get("hex", "")
-
-    token_hits = detect_token_patterns(all_hex)
-    signals |= token_hits
-
-    analysis.bip110_flags = bip110
-    analysis.signals = signals
-    analysis.witness_bytes = witness_bytes
-    return analysis
+    detected = run_detectors(tx)
+    return TxAnalysis(
+        txid=txid,
+        weight=weight,
+        vsize=vsize,
+        bip110_flags=detected.bip110_flags,
+        signals=detected.signals,
+        witness_bytes=detected.witness_bytes,
+    )
 
 
 def analyze_block(
@@ -254,6 +100,7 @@ def analyze_block(
 
     miner_tag = "unknown"
     tx_analyses: list[TxAnalysis] = []
+    flagged_raw: dict[str, dict[str, Any]] = {}
     total_witness = 0
 
     for tx in txs:
@@ -266,6 +113,10 @@ def analyze_block(
         ta = analyze_transaction(tx)
         tx_analyses.append(ta)
         total_witness += ta.witness_bytes
+        if ta.has_bip110_violation or ta.is_spam_signal:
+            txid = ta.txid or tx.get("txid", "")
+            if txid:
+                flagged_raw[txid] = tx
 
     violation_count = sum(1 for t in tx_analyses if t.has_bip110_violation)
     violation_weight = sum(t.weight for t in tx_analyses if t.has_bip110_violation)
@@ -317,4 +168,8 @@ def analyze_block(
         large_witness_bytes=large_witness_bytes,
         witness_pct=witness_pct,
         transactions=tx_analyses,
+        flagged_raw=flagged_raw,
     )
+
+
+configure_detectors(["builtin"])

--- a/pybitblock/oraclevision/bitcoin_cli.py
+++ b/pybitblock/oraclevision/bitcoin_cli.py
@@ -121,6 +121,41 @@ class BitcoinCLI:
     def decode_raw_transaction(self, hex_data: str) -> dict[str, Any]:
         return self.call("decoderawtransaction", hex_data)
 
+    def get_raw_mempool(self, *, verbose: bool = False) -> Any:
+        return self.call("getrawmempool", verbose)
+
+    def get_raw_transaction(
+        self,
+        txid: str,
+        verbose: bool = True,
+        *,
+        block_hash: str | None = None,
+    ) -> Any:
+        if block_hash:
+            return self.call("getrawtransaction", txid, verbose, block_hash)
+        return self.call("getrawtransaction", txid, verbose)
+
+    def get_blockchain_info(self) -> dict[str, Any]:
+        return self.call("getblockchaininfo")
+
+    def validate_address(self, address: str) -> dict[str, Any]:
+        return self.call("validateaddress", address)
+
+    def scantxoutset_address(
+        self,
+        address: str,
+        *,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Scan UTXO set for a single address via scantxoutset."""
+        original_timeout = self.timeout
+        if timeout is not None:
+            self.timeout = timeout
+        try:
+            return self.call("scantxoutset", "start", [f"addr({address})"])
+        finally:
+            self.timeout = original_timeout
+
     @classmethod
     def from_path_config(cls, path: dict[str, str], datadir: str = "", timeout: float = 60.0) -> "BitcoinCLI":
         return cls(path.get("bitcoincli", "bitcoin-cli"), datadir=datadir, timeout=timeout)

--- a/pybitblock/oraclevision/config.py
+++ b/pybitblock/oraclevision/config.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from config import cfg
+from oraclevision.detectors import configure_detectors
 from oraclevision.security import validate_safe_path_token
 
 
@@ -24,7 +25,20 @@ _DEFAULTS = {
     "bitcoin_datadir": "",
     "oraculovision_command": "oraculovision",
     "cli_timeout_seconds": 60,
+    "max_vin_lookups": 4,
+    "scantxoutset_timeout": 90,
+    "mempool_scan_limit": 30,
+    "detectors_enabled": ["builtin"],
 }
+
+
+@dataclass
+class InspectorConfig:
+    """Transaction and address inspector settings."""
+
+    max_vin_lookups: int = 4
+    scantxoutset_timeout: float = 90.0
+    mempool_scan_limit: int = 30
 
 
 @dataclass
@@ -34,12 +48,32 @@ class OracleVisionSettings:
     bitcoin_datadir: str = ""
     oraculovision_command: str = "oraculovision"
     cli_timeout_seconds: int = 60
+    max_vin_lookups: int = 4
+    scantxoutset_timeout: float = 90.0
+    mempool_scan_limit: int = 30
+    detectors_enabled: list[str] = field(default_factory=lambda: ["builtin"])
     load_error: str | None = None
+
+    @property
+    def inspector(self) -> InspectorConfig:
+        return InspectorConfig(
+            max_vin_lookups=self.max_vin_lookups,
+            scantxoutset_timeout=self.scantxoutset_timeout,
+            mempool_scan_limit=self.mempool_scan_limit,
+        )
 
 
 def _safe_int(value: object, default: int, *, field: str, errors: list[str]) -> int:
     try:
         return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        errors.append(f"Invalid {field}; using default {default}")
+        return default
+
+
+def _safe_float(value: object, default: float, *, field: str, errors: list[str]) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         errors.append(f"Invalid {field}; using default {default}")
         return default
@@ -91,7 +125,14 @@ def load_settings() -> OracleVisionSettings:
         errors.append(str(exc))
         oraculovision_command = _DEFAULTS["oraculovision_command"]
 
-    return OracleVisionSettings(
+    detectors_enabled = data.get("detectors_enabled", ["builtin"])
+    if not isinstance(detectors_enabled, list):
+        errors.append("detectors_enabled must be a list; using ['builtin']")
+        detectors_enabled = ["builtin"]
+    else:
+        detectors_enabled = [str(name) for name in detectors_enabled]
+
+    settings = OracleVisionSettings(
         block_scan_count=_safe_int(
             data.get("block_scan_count", 10), 10, field="block_scan_count", errors=errors
         ),
@@ -103,5 +144,18 @@ def load_settings() -> OracleVisionSettings:
         cli_timeout_seconds=_safe_int(
             data.get("cli_timeout_seconds", 60), 60, field="cli_timeout_seconds", errors=errors
         ),
+        max_vin_lookups=_safe_int(
+            data.get("max_vin_lookups", 4), 4, field="max_vin_lookups", errors=errors
+        ),
+        scantxoutset_timeout=_safe_float(
+            data.get("scantxoutset_timeout", 90), 90.0, field="scantxoutset_timeout", errors=errors
+        ),
+        mempool_scan_limit=_safe_int(
+            data.get("mempool_scan_limit", 30), 30, field="mempool_scan_limit", errors=errors
+        ),
+        detectors_enabled=detectors_enabled,
         load_error="; ".join(errors) if errors else None,
     )
+
+    configure_detectors(settings.detectors_enabled)
+    return settings

--- a/pybitblock/oraclevision/detectors/__init__.py
+++ b/pybitblock/oraclevision/detectors/__init__.py
@@ -1,0 +1,74 @@
+"""Pluggable transaction detector registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+_DEFAULT_ENABLED = ("builtin",)
+
+
+@dataclass
+class DetectorResult:
+    bip110_flags: set[str] = field(default_factory=set)
+    signals: set[str] = field(default_factory=set)
+    witness_bytes: int = 0
+
+
+class TxDetector(Protocol):
+    name: str
+
+    def detect(self, tx: dict[str, Any]) -> DetectorResult: ...
+
+
+_REGISTRY: dict[str, TxDetector] = {}
+_ACTIVE: tuple[str, ...] = _DEFAULT_ENABLED
+
+
+def register(detector: TxDetector) -> None:
+    _REGISTRY[detector.name] = detector
+
+
+def set_enabled(names: list[str] | tuple[str, ...] | None) -> None:
+    global _ACTIVE
+    if not names:
+        _ACTIVE = _DEFAULT_ENABLED
+        return
+    _ACTIVE = tuple(names)
+
+
+def enabled_detectors() -> tuple[str, ...]:
+    return _ACTIVE
+
+
+def run_detectors(tx: dict[str, Any], *, enabled: tuple[str, ...] | None = None) -> DetectorResult:
+    names = enabled or _ACTIVE
+    combined = DetectorResult()
+    for name in names:
+        detector = _REGISTRY.get(name)
+        if detector is None:
+            continue
+        result = detector.detect(tx)
+        combined.bip110_flags |= result.bip110_flags
+        combined.signals |= result.signals
+        combined.witness_bytes = max(combined.witness_bytes, result.witness_bytes)
+    return combined
+
+
+def _ensure_builtin_registered() -> None:
+    if "builtin" not in _REGISTRY:
+        from oraclevision.detectors.builtin import BuiltinDetector
+
+        register(BuiltinDetector())
+
+
+def configure_detectors(enabled: list[str] | None = None) -> None:
+    """Load built-in detectors and apply config-enabled list."""
+    _ensure_builtin_registered()
+    if enabled:
+        for name in enabled:
+            if name == "example_dust":
+                from oraclevision.detectors.example_dust import DustDetector
+
+                register(DustDetector())
+    set_enabled(enabled)

--- a/pybitblock/oraclevision/detectors/builtin.py
+++ b/pybitblock/oraclevision/detectors/builtin.py
@@ -1,0 +1,181 @@
+"""Built-in BIP-110 and spam signal detectors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from oraclevision.detectors import DetectorResult, TxDetector
+from oraclevision.script_parser import (
+    MAX_CONTROL_BLOCK_SIZE,
+    MAX_OPRETURN_SIZE,
+    MAX_PUSHDATA_SIZE,
+    MAX_SCRIPTPUBKEY_SIZE,
+    detect_inscription_in_witness,
+    detect_token_patterns,
+    has_annex,
+    infer_taproot_script_path,
+    is_op_return,
+    is_valid_taproot_control_block,
+    scan_tapscript_violations,
+    script_has_large_push,
+    vout_script_size,
+    witness_total_bytes,
+)
+
+
+def _prevout_type(vin: dict) -> str | None:
+    if isinstance(vin.get("prevout"), dict):
+        spk = vin["prevout"].get("scriptPubKey", {})
+        return spk.get("type")
+    return None
+
+
+def _check_witness_rules(vin: dict) -> set[str]:
+    flags: set[str] = set()
+    witness: list[str] = vin.get("txinwitness") or vin.get("witness") or []
+    if not witness:
+        return flags
+
+    annex = has_annex(witness)
+    prevout_type = _prevout_type(vin)
+    is_taproot_prevout = prevout_type == "witness_v1_taproot" or prevout_type == "v1_p2tr"
+    is_script_path = (
+        (is_taproot_prevout and len(witness) > (2 if annex else 1))
+        or infer_taproot_script_path(witness)
+    )
+
+    if annex and (is_taproot_prevout or is_script_path):
+        flags.add("taproot_annex")
+
+    exempt: set[int] = set()
+    executing_scripts: list[int] = []
+
+    if annex:
+        exempt.add(len(witness) - 1)
+
+    if is_script_path:
+        cb_idx = len(witness) - (2 if annex else 1)
+        tap_idx = cb_idx - 1
+        exempt.add(cb_idx)
+        if tap_idx >= 0:
+            exempt.add(tap_idx)
+            executing_scripts.append(tap_idx)
+    elif is_taproot_prevout:
+        sig_idx = len(witness) - 1 - (1 if annex else 0)
+        if sig_idx >= 0:
+            exempt.add(sig_idx)
+    elif prevout_type in ("witness_v0_scripthash", "v0_p2wsh", "scripthash", "p2sh") or prevout_type is None:
+        ws_idx = len(witness) - 1 - (1 if annex else 0)
+        if ws_idx >= 0:
+            exempt.add(ws_idx)
+            executing_scripts.append(ws_idx)
+
+    for i, item in enumerate(witness):
+        if i in exempt:
+            continue
+        if len(item) // 2 > MAX_PUSHDATA_SIZE:
+            flags.add("large_pushdata")
+            break
+
+    if is_script_path:
+        cb_idx = len(witness) - (2 if annex else 1)
+        cb = witness[cb_idx]
+        if len(cb) // 2 > MAX_CONTROL_BLOCK_SIZE:
+            flags.add("large_control_block")
+        if is_valid_taproot_control_block(cb):
+            leaf_version = int(cb[:2], 16) & 0xFE
+            if leaf_version != 0xC0:
+                flags.add("undefined_witness")
+        tap_idx = cb_idx - 1
+        if tap_idx >= 0:
+            tapscript = witness[tap_idx]
+            op_success, op_if = scan_tapscript_violations(tapscript)
+            if op_success:
+                flags.add("op_success")
+            if op_if:
+                flags.add("op_if_notif")
+
+    if "large_pushdata" not in flags:
+        for idx in executing_scripts:
+            if script_has_large_push(witness[idx]):
+                flags.add("large_pushdata")
+                break
+
+    return flags
+
+
+def _check_scriptsig_rules(vin: dict) -> set[str]:
+    flags: set[str] = set()
+    scriptsig = vin.get("scriptSig", {})
+    hex_sig = scriptsig.get("hex", "") if isinstance(scriptsig, dict) else ""
+    if not hex_sig:
+        return flags
+
+    asm = scriptsig.get("asm", "") if isinstance(scriptsig, dict) else ""
+    if asm:
+        parts = asm.split()
+        prevout_type = _prevout_type(vin)
+        redeem_idx = len(parts) - 1 if prevout_type in ("scripthash", "p2sh") else -1
+        for i, part in enumerate(parts):
+            if part.startswith("OP_"):
+                continue
+            if i == redeem_idx:
+                if script_has_large_push(part):
+                    flags.add("large_pushdata")
+                continue
+            if len(part) // 2 > MAX_PUSHDATA_SIZE:
+                flags.add("large_pushdata")
+                break
+    elif script_has_large_push(hex_sig):
+        flags.add("large_pushdata")
+    return flags
+
+
+class BuiltinDetector:
+    """Default Knots BIP-110 and spam signal detection."""
+
+    name = "builtin"
+
+    def detect(self, tx: dict[str, Any]) -> DetectorResult:
+        bip110: set[str] = set()
+        signals: set[str] = set()
+        witness_bytes = 0
+        all_hex = str(tx.get("txid", tx.get("hash", "")))
+
+        for vout in tx.get("vout", []):
+            size = vout_script_size(vout)
+            if is_op_return(vout):
+                signals.add("op_return")
+                if size > MAX_OPRETURN_SIZE:
+                    bip110.add("large_scriptpubkey")
+            elif size > MAX_SCRIPTPUBKEY_SIZE:
+                bip110.add("large_scriptpubkey")
+
+        for vin in tx.get("vin", []):
+            if vin.get("coinbase"):
+                continue
+            witness: list[str] = vin.get("txinwitness") or vin.get("witness") or []
+            witness_bytes += witness_total_bytes(witness)
+            all_hex += "".join(witness)
+
+            bip110 |= _check_witness_rules(vin)
+            bip110 |= _check_scriptsig_rules(vin)
+
+            if detect_inscription_in_witness(witness):
+                signals.add("inscription")
+
+            scriptsig = vin.get("scriptSig", {})
+            if isinstance(scriptsig, dict):
+                all_hex += scriptsig.get("hex", "")
+
+        for vout in tx.get("vout", []):
+            spk = vout.get("scriptPubKey", {})
+            all_hex += spk.get("hex", "")
+
+        signals |= detect_token_patterns(all_hex)
+
+        return DetectorResult(
+            bip110_flags=bip110,
+            signals=signals,
+            witness_bytes=witness_bytes,
+        )

--- a/pybitblock/oraclevision/markup.py
+++ b/pybitblock/oraclevision/markup.py
@@ -1,0 +1,6 @@
+"""Safe embedding of user/node text inside Rich markup."""
+
+
+def safe_markup_text(text: str) -> str:
+    """Escape arbitrary text so square brackets are not parsed as markup tags."""
+    return text.replace("\\", "\\\\").replace("[", "\\[")

--- a/pybitblock/oraclevision/mempool_compose.py
+++ b/pybitblock/oraclevision/mempool_compose.py
@@ -37,6 +37,14 @@ class MempoolComposition:
     source: str = "block_template"
     error: str | None = None
 
+    @property
+    def sampled_tx(self) -> int:
+        return self.analyzed_tx
+
+    @property
+    def sampled_weight(self) -> int:
+        return self.analyzed_weight
+
     def pct(self, weight: int) -> float:
         base = self.analyzed_weight or 1
         return (weight / base) * 100

--- a/pybitblock/oraclevision/tx_flow.py
+++ b/pybitblock/oraclevision/tx_flow.py
@@ -1,0 +1,193 @@
+"""Pure transaction flow parsing — inputs, outputs, amounts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class TxIO:
+    index: int
+    address: str | None
+    value_btc: float
+    script_type: str
+    role: str
+    label: str = ""
+
+    @property
+    def display_address(self) -> str:
+        if self.label:
+            return self.label
+        if self.address:
+            return self.address
+        if self.script_type == "nulldata":
+            return "OP_RETURN"
+        return "unknown"
+
+
+@dataclass
+class TxFlowSummary:
+    inputs: list[TxIO] = field(default_factory=list)
+    outputs: list[TxIO] = field(default_factory=list)
+    total_input_btc: float = 0.0
+    total_output_btc: float = 0.0
+    fee_btc: float | None = None
+    senders: list[str] = field(default_factory=list)
+    recipients: list[str] = field(default_factory=list)
+    inputs_resolved: bool = False
+    inputs_partial: bool = False
+
+    @property
+    def all_addresses(self) -> list[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for io in (*self.inputs, *self.outputs):
+            if io.address and io.address not in seen:
+                seen.add(io.address)
+                ordered.append(io.address)
+        return ordered
+
+
+def _script_address(spk: dict[str, Any]) -> str | None:
+    if not spk:
+        return None
+    addr = spk.get("address")
+    if isinstance(addr, str) and addr:
+        return addr
+    addresses = spk.get("addresses")
+    if isinstance(addresses, list) and addresses:
+        first = addresses[0]
+        if isinstance(first, str) and first:
+            return first
+    return None
+
+
+def _script_type(spk: dict[str, Any]) -> str:
+    return str(spk.get("type") or spk.get("asm", "unknown") or "unknown")
+
+
+def _is_op_return(spk: dict[str, Any]) -> bool:
+    return _script_type(spk) in ("nulldata", "op_return") or str(spk.get("asm", "")).startswith("OP_RETURN")
+
+
+def parse_outputs(tx: dict[str, Any]) -> list[TxIO]:
+    outputs: list[TxIO] = []
+    for vout in tx.get("vout", []):
+        if not isinstance(vout, dict):
+            continue
+        index = int(vout.get("n", len(outputs)))
+        spk = vout.get("scriptPubKey") or {}
+        value = float(vout.get("value", 0) or 0)
+        script_type = _script_type(spk)
+        if _is_op_return(spk):
+            outputs.append(
+                TxIO(
+                    index=index,
+                    address=None,
+                    value_btc=value,
+                    script_type="nulldata",
+                    role="output",
+                    label="OP_RETURN",
+                )
+            )
+            continue
+        outputs.append(
+            TxIO(
+                index=index,
+                address=_script_address(spk),
+                value_btc=value,
+                script_type=script_type,
+                role="output",
+            )
+        )
+    return outputs
+
+
+def parse_inputs_from_tx(tx: dict[str, Any]) -> list[TxIO]:
+    inputs: list[TxIO] = []
+    for idx, vin in enumerate(tx.get("vin", [])):
+        if not isinstance(vin, dict):
+            continue
+        if vin.get("coinbase"):
+            inputs.append(
+                TxIO(
+                    index=idx,
+                    address=None,
+                    value_btc=0.0,
+                    script_type="coinbase",
+                    role="input",
+                    label="coinbase",
+                )
+            )
+            continue
+
+        prevout = vin.get("prevout")
+        if isinstance(prevout, dict):
+            spk = prevout.get("scriptPubKey") or {}
+            value = float(prevout.get("value", 0) or 0)
+            inputs.append(
+                TxIO(
+                    index=idx,
+                    address=_script_address(spk),
+                    value_btc=value,
+                    script_type=_script_type(spk),
+                    role="input",
+                )
+            )
+        else:
+            inputs.append(
+                TxIO(
+                    index=idx,
+                    address=None,
+                    value_btc=0.0,
+                    script_type="unknown",
+                    role="input",
+                    label="prevout unavailable",
+                )
+            )
+    return inputs
+
+
+def build_flow_summary(
+    tx: dict[str, Any],
+    *,
+    resolved_inputs: list[TxIO] | None = None,
+) -> TxFlowSummary:
+    """Build economic flow summary from a raw transaction dict."""
+    outputs = parse_outputs(tx)
+    inputs = resolved_inputs if resolved_inputs is not None else parse_inputs_from_tx(tx)
+
+    spend_inputs = [io for io in inputs if io.label != "coinbase"]
+    known_inputs = [io for io in spend_inputs if io.label != "prevout unavailable" and io.address]
+    inputs_resolved = bool(spend_inputs) and all(
+        io.label != "prevout unavailable" for io in spend_inputs
+    )
+    inputs_partial = bool(spend_inputs) and not inputs_resolved and bool(known_inputs)
+
+    total_in = sum(io.value_btc for io in known_inputs)
+    total_out = sum(io.value_btc for io in outputs if io.script_type != "nulldata")
+
+    fee_btc: float | None = None
+    if inputs_resolved and total_in > 0:
+        fee_btc = max(0.0, total_in - total_out)
+
+    senders = list(dict.fromkeys(io.address for io in known_inputs if io.address))
+    recipients = list(
+        dict.fromkeys(
+            io.address for io in outputs
+            if io.address and io.script_type != "nulldata"
+        )
+    )
+
+    return TxFlowSummary(
+        inputs=inputs,
+        outputs=outputs,
+        total_input_btc=total_in,
+        total_output_btc=total_out,
+        fee_btc=fee_btc,
+        senders=senders,
+        recipients=recipients,
+        inputs_resolved=inputs_resolved,
+        inputs_partial=inputs_partial,
+    )

--- a/pybitblock/oraclevision/tx_service.py
+++ b/pybitblock/oraclevision/tx_service.py
@@ -1,0 +1,463 @@
+"""Transaction fetch and deep analysis for PyBLOCK's terminal inspector."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from oraclevision.bip110 import TxAnalysis, analyze_transaction
+from oraclevision.mempool_compose import categorize_transaction
+from oraclevision.bitcoin_cli import BitcoinCLI, BitcoinCLIError
+from oraclevision.config import InspectorConfig
+from oraclevision.markup import safe_markup_text
+from oraclevision.tx_flow import TxFlowSummary, TxIO, build_flow_summary, parse_inputs_from_tx
+
+_TXID_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class TxQueryError(ValueError):
+    """Invalid or unresolvable transaction query."""
+
+
+@dataclass
+class TxInspectContext:
+    """Optional hints when inspecting from Block Detail or Mempool Glass."""
+
+    block_hash: str | None = None
+    block_height: int | None = None
+    raw_tx: dict[str, Any] | None = None
+    cached_analysis: TxAnalysis | None = None
+
+
+@dataclass
+class TxInspection:
+    """Full inspection result for a transaction."""
+
+    txid: str
+    raw: dict[str, Any]
+    analysis: TxAnalysis
+    category: str
+    in_mempool: bool = False
+    confirmed: bool = False
+    block_hash: str | None = None
+    block_height: int | None = None
+    fee_btc: float | None = None
+    fee_rate: float | None = None
+    mempool_descendant_count: int | None = None
+    partial: bool = False
+    source_note: str | None = None
+    error: str | None = None
+    flow: TxFlowSummary | None = None
+
+    @property
+    def compliance_label(self) -> str:
+        if self.analysis.has_bip110_violation:
+            return "BIP-110 VIOLATION"
+        if self.analysis.is_spam_signal:
+            return "SPAM SIGNAL"
+        if self.category != "economic":
+            return self.category.upper()
+        return "CLEAN"
+
+
+def parse_tx_query(raw: str) -> str:
+    """Validate and normalize a txid query."""
+    txid = (raw or "").strip().lower()
+    if not txid:
+        raise TxQueryError("Enter a 64-character transaction ID (txid)")
+    if not _TXID_RE.fullmatch(txid):
+        raise TxQueryError("Invalid txid — must be 64 hexadecimal characters")
+    return txid
+
+
+def _category_from_analysis(analysis: TxAnalysis) -> str:
+    if analysis.has_bip110_violation or analysis.is_spam_signal:
+        return "spam"
+    return "economic"
+
+
+def _truncate_addr(address: str, width: int = 20) -> str:
+    if len(address) <= width:
+        return address
+    return f"{address[:width - 1]}…"
+
+
+def _format_io_table(title: str, rows: list[TxIO]) -> list[str]:
+    lines = [f"[bold rgb(255,215,0)]{title}[/]"]
+    if not rows:
+        lines.append("  [dim]none[/]")
+        return lines
+    for io in rows:
+        addr = safe_markup_text(_truncate_addr(io.display_address, 44))
+        value = f"{io.value_btc:.8f} BTC"
+        stype = safe_markup_text(io.script_type)
+        lines.append(f"  [{io.index}] {addr}  {value}  ({stype})")
+    return lines
+
+
+class TxService:
+    """Fetch and analyze transactions via the local node."""
+
+    def __init__(
+        self,
+        cli: BitcoinCLI,
+        config: InspectorConfig | None = None,
+    ) -> None:
+        self.cli = cli
+        self.config = config or InspectorConfig()
+
+    def inspect(
+        self,
+        raw_query: str,
+        context: TxInspectContext | None = None,
+    ) -> TxInspection:
+        txid = parse_tx_query(raw_query)
+        return self.inspect_txid(txid, context=context)
+
+    def inspect_txid(
+        self,
+        txid: str,
+        *,
+        context: TxInspectContext | None = None,
+    ) -> TxInspection:
+        ctx = context or TxInspectContext()
+        in_mempool = False
+        mempool_entry: dict[str, Any] | None = None
+
+        try:
+            mempool = self.cli.get_raw_mempool(verbose=True)
+            if isinstance(mempool, dict) and txid in mempool:
+                in_mempool = True
+                mempool_entry = mempool[txid]
+        except BitcoinCLIError:
+            pass
+
+        tx, source_note = self._resolve_raw_tx(txid, ctx)
+
+        if tx is None:
+            if ctx.cached_analysis is not None:
+                return self._partial_inspection(
+                    txid,
+                    ctx.cached_analysis,
+                    ctx,
+                    in_mempool=in_mempool,
+                )
+            raise TxQueryError(self._not_found_message(txid, ctx))
+
+        if not isinstance(tx, dict):
+            raise TxQueryError("Unexpected response from getrawtransaction")
+
+        analysis = analyze_transaction(tx)
+        category = categorize_transaction(tx)
+
+        confirmed = bool(tx.get("blockhash") or ctx.block_hash)
+        block_hash = tx.get("blockhash") or ctx.block_hash
+        block_height = tx.get("blockheight") or ctx.block_height
+        if block_height is not None:
+            block_height = int(block_height)
+
+        flow = self._enrich_flow(tx)
+        fee_btc, fee_rate = _extract_fees(tx, mempool_entry, flow)
+
+        return TxInspection(
+            txid=txid,
+            raw=tx,
+            analysis=analysis,
+            category=category,
+            in_mempool=in_mempool,
+            confirmed=confirmed,
+            block_hash=block_hash,
+            block_height=block_height,
+            fee_btc=fee_btc,
+            fee_rate=fee_rate,
+            mempool_descendant_count=(
+                int(mempool_entry["descendantcount"])
+                if mempool_entry and "descendantcount" in mempool_entry
+                else None
+            ),
+            source_note=source_note,
+            flow=flow,
+        )
+
+    def _enrich_flow(self, tx: dict[str, Any]) -> TxFlowSummary:
+        inputs = parse_inputs_from_tx(tx)
+        lookups = 0
+        max_lookups = max(0, self.config.max_vin_lookups)
+
+        for io in inputs:
+            if io.label != "prevout unavailable":
+                continue
+            if lookups >= max_lookups:
+                break
+            vin = tx.get("vin", [])
+            if io.index >= len(vin):
+                continue
+            vin_entry = vin[io.index]
+            if not isinstance(vin_entry, dict):
+                continue
+            parent_txid = vin_entry.get("txid")
+            parent_vout = vin_entry.get("vout")
+            if parent_txid is None or parent_vout is None:
+                continue
+            try:
+                parent = self.cli.get_raw_transaction(str(parent_txid), True)
+            except BitcoinCLIError:
+                lookups += 1
+                continue
+            lookups += 1
+            if not isinstance(parent, dict):
+                continue
+            vouts = parent.get("vout", [])
+            if not isinstance(parent_vout, int) or parent_vout >= len(vouts):
+                continue
+            prevout = vouts[parent_vout]
+            if not isinstance(prevout, dict):
+                continue
+            spk = prevout.get("scriptPubKey") or {}
+            io.address = spk.get("address") or (
+                (spk.get("addresses") or [None])[0]
+            )
+            io.value_btc = float(prevout.get("value", 0) or 0)
+            io.script_type = str(spk.get("type") or "unknown")
+            io.label = ""
+
+        return build_flow_summary(tx, resolved_inputs=inputs)
+
+    def _resolve_raw_tx(
+        self,
+        txid: str,
+        ctx: TxInspectContext,
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        if ctx.raw_tx and isinstance(ctx.raw_tx, dict):
+            raw = dict(ctx.raw_tx)
+            if not raw.get("txid"):
+                raw["txid"] = txid
+            return raw, "Loaded from block analysis cache (no extra RPC)"
+
+        attempts: list[tuple[str | None, str]] = [
+            (None, "getrawtransaction"),
+        ]
+        if ctx.block_hash:
+            attempts.append((ctx.block_hash, "getrawtransaction + blockhash"))
+
+        last_exc: BitcoinCLIError | None = None
+        for block_hash, label in attempts:
+            try:
+                tx = self.cli.get_raw_transaction(
+                    txid,
+                    True,
+                    block_hash=block_hash,
+                )
+                if isinstance(tx, dict):
+                    note = f"Verified via {label} on your node"
+                    if block_hash and label.endswith("blockhash"):
+                        note += " (pruned-node compatible)"
+                    return tx, note
+            except BitcoinCLIError as exc:
+                last_exc = exc
+
+        if last_exc:
+            _ = last_exc
+        return None, None
+
+    def _partial_inspection(
+        self,
+        txid: str,
+        cached: TxAnalysis,
+        ctx: TxInspectContext,
+        *,
+        in_mempool: bool,
+    ) -> TxInspection:
+        note = (
+            "Partial view from block scan — raw tx not on disk "
+            "(pruned node or block pruned). Flags and signals are from "
+            "getblock analysis at scan time."
+        )
+        raw = ctx.raw_tx if isinstance(ctx.raw_tx, dict) else {"vin": [], "vout": [], "txid": txid}
+        flow = build_flow_summary(raw) if raw.get("vout") else None
+        return TxInspection(
+            txid=txid,
+            raw=raw,
+            analysis=cached,
+            category=_category_from_analysis(cached),
+            in_mempool=in_mempool,
+            confirmed=True,
+            block_hash=ctx.block_hash,
+            block_height=ctx.block_height,
+            partial=True,
+            source_note=note,
+            flow=flow,
+        )
+
+    def _not_found_message(self, txid: str, ctx: TxInspectContext) -> str:
+        lines = [
+            "Transaction not found in mempool or on-disk chain.",
+        ]
+        try:
+            chain = self.cli.get_blockchain_info()
+            if chain.get("pruned"):
+                prune_h = chain.get("pruneheight", "?")
+                lines.append(
+                    f"Your node is pruned (prune height #{prune_h:,}). "
+                    "Older confirmed txs are not stored unless you pass block context."
+                )
+                lines.append(
+                    "Tip: inspect from Block Detail View after scanning a block, "
+                    "or enable txindex=1 on a full archival node."
+                )
+            else:
+                lines.append(
+                    "On a full node, enable txindex=1 and reindex for arbitrary history."
+                )
+        except BitcoinCLIError:
+            pass
+
+        if ctx.block_hash:
+            lines.append(
+                f"Block context #{ctx.block_height or '?'} was provided but "
+                "getrawtransaction still failed — block may be pruned away."
+            )
+
+        short = f"{txid[:16]}…"
+        return f"{lines[0]} ({short})\n" + "\n".join(lines[1:])
+
+
+def _extract_fees(
+    tx: dict[str, Any],
+    mempool_entry: dict[str, Any] | None,
+    flow: TxFlowSummary | None,
+) -> tuple[float | None, float | None]:
+    """Return (fee_btc, fee_rate_sat_vb) when available."""
+    fee_btc: float | None = None
+    fee_rate: float | None = None
+
+    if mempool_entry:
+        fees = mempool_entry.get("fees") or {}
+        base = fees.get("base")
+        if base is not None:
+            fee_btc = float(base)
+        vsize = int(mempool_entry.get("vsize") or tx.get("vsize") or 0)
+        if fee_btc is not None and vsize > 0:
+            fee_rate = (fee_btc * 100_000_000) / vsize
+
+    if fee_btc is None and "fee" in tx:
+        fee_btc = float(tx["fee"])
+        vsize = int(tx.get("vsize") or 0)
+        if vsize > 0:
+            fee_rate = (abs(fee_btc) * 100_000_000) / vsize
+
+    if fee_btc is None and flow and flow.fee_btc is not None:
+        fee_btc = flow.fee_btc
+        vsize = int(tx.get("vsize") or 0)
+        if vsize > 0:
+            fee_rate = (fee_btc * 100_000_000) / vsize
+
+    return fee_btc, fee_rate
+
+
+def format_inspection(ins: TxInspection) -> str:
+    """Render inspection as Rich markup text."""
+    a = ins.analysis
+    lines: list[str] = []
+
+    if ins.partial:
+        lines.extend([
+            "[yellow bold]PARTIAL INSPECTION[/]",
+            f"[dim]{ins.source_note}[/]",
+            "",
+        ])
+    elif ins.source_note:
+        lines.extend([
+            f"[dim]{ins.source_note}[/]",
+            "",
+        ])
+
+    lines.extend([
+        f"[bold rgb(255,215,0)]Transaction[/]  {ins.txid}",
+        "",
+        f"[bold]Status[/]      "
+        + ("mempool" if ins.in_mempool else "not in mempool")
+        + ("  ·  confirmed" if ins.confirmed else "  ·  unconfirmed"),
+    ])
+
+    if ins.block_height is not None:
+        lines.append(f"[bold]Block[/]       #{ins.block_height}  {ins.block_hash or ''}")
+    if ins.fee_btc is not None:
+        fee_line = f"[bold]Fee[/]         {ins.fee_btc:.8f} BTC"
+        if ins.fee_rate is not None:
+            fee_line += f"  ({ins.fee_rate:.2f} sat/vB)"
+        lines.append(fee_line)
+    if ins.mempool_descendant_count is not None:
+        lines.append(
+            f"[bold]Descendants[/] {ins.mempool_descendant_count} in mempool package"
+        )
+
+    if ins.flow:
+        flow = ins.flow
+        lines.extend(["", "[bold rgb(255,215,0)]─── FLOW ───[/]"])
+        in_note = f"  ({len(flow.inputs)} inputs)"
+        out_note = f"  ({len(flow.outputs)} outputs)"
+        if flow.inputs_resolved or flow.total_input_btc > 0:
+            lines.append(f"  In:   {flow.total_input_btc:.8f} BTC{in_note}")
+        elif flow.inputs_partial:
+            lines.append(f"  In:   [dim]partial — some prevouts unavailable (pruned)[/]{in_note}")
+        else:
+            lines.append(f"  In:   [dim]unknown (prevouts not resolved)[/]{in_note}")
+        lines.append(f"  Out:  {flow.total_output_btc:.8f} BTC{out_note}")
+        if flow.senders:
+            senders = ", ".join(_truncate_addr(a) for a in flow.senders[:4])
+            lines.append(f"  From: {safe_markup_text(senders)}")
+        if flow.recipients:
+            recips = ", ".join(_truncate_addr(a) for a in flow.recipients[:4])
+            lines.append(f"  To:   {safe_markup_text(recips)}")
+        lines.append("")
+        lines.extend(_format_io_table("INPUTS", flow.inputs))
+        lines.append("")
+        lines.extend(_format_io_table("OUTPUTS", flow.outputs))
+
+    cat_style = {
+        "economic": "green",
+        "spam": "red bold",
+        "coinjoin": "blue",
+        "consolidation": "cyan",
+    }.get(ins.category, "white")
+
+    comp_style = (
+        "red bold" if a.has_bip110_violation
+        else "yellow" if a.is_spam_signal
+        else "green"
+    )
+
+    lines.extend([
+        "",
+        f"[bold]Size[/]        weight {a.weight:,}  ·  vsize {a.vsize:,}",
+        f"[bold]Witness[/]    {a.witness_bytes:,} bytes",
+        f"[bold]Category[/]   [{cat_style}]{ins.category}[/]",
+        f"[bold]Compliance[/] [{comp_style}]{ins.compliance_label}[/]",
+        "",
+        "[bold rgb(255,215,0)]BIP-110 flags[/]",
+    ])
+
+    if a.bip110_flags:
+        lines.append("  " + ", ".join(sorted(a.bip110_flags)))
+    else:
+        lines.append("  [green]none[/]")
+
+    lines.append("[bold rgb(255,215,0)]Spam signals[/]")
+    if a.signals:
+        lines.append("  " + ", ".join(sorted(a.signals)))
+    else:
+        lines.append("  [green]none[/]")
+
+    if ins.partial:
+        lines.extend([
+            "",
+            "[dim]Full input addresses require prevout in block cache or archival node[/]",
+        ])
+    else:
+        lines.extend([
+            "",
+            "[dim]Verified locally via your node — no third-party explorer[/]",
+        ])
+    return "\n".join(lines)

--- a/pybitblock/oraclevision/ui.py
+++ b/pybitblock/oraclevision/ui.py
@@ -13,12 +13,20 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from oraclevision.bip110 import BlockAnalysis, analyze_block
+from oraclevision.address_service import AddressService, format_address_inspection
+from oraclevision.addresses import AddressQueryError, classify_query
+from oraclevision.bip110 import BlockAnalysis, TxAnalysis, analyze_block
 from oraclevision.bitcoin_cli import BitcoinCLI, BitcoinCLIError
 from oraclevision.config import load_settings
 from oraclevision.mempool_compose import analyze_block_template
 from oraclevision.security import resolve_executable
 from oraclevision.spam_score import status_style
+from oraclevision.tx_service import (
+    TxInspectContext,
+    TxQueryError,
+    TxService,
+    format_inspection,
+)
 from shared.display import clear
 from shared.rich_ui import console, rich_error, rich_prompt
 from shared.ui import show_error
@@ -43,7 +51,8 @@ def _menu_items() -> None:
     console.print("    [bold cyan]A.[/] BIP-110 Block Scanner")
     console.print("    [bold cyan]B.[/] Mempool Glass (getblocktemplate)")
     console.print("    [bold cyan]C.[/] Block Detail View")
-    console.print("    [bold cyan]D.[/] Launch Full OracleVision TUI")
+    console.print("    [bold cyan]D.[/] Transaction & Address Inspector")
+    console.print("    [bold cyan]E.[/] Launch Full OracleVision TUI")
     console.print("    [bold yellow]R.[/] Return")
     console.print()
 
@@ -55,6 +64,24 @@ def _cli_for(path: dict) -> BitcoinCLI:
         datadir=settings.bitcoin_datadir,
         timeout=float(settings.cli_timeout_seconds),
     )
+
+
+def _inspection_border_style(
+    *,
+    partial: bool = False,
+    has_violation: bool = False,
+    is_spam: bool = False,
+    address_mode: bool = False,
+) -> str:
+    if partial:
+        return "yellow"
+    if has_violation:
+        return "red"
+    if is_spam:
+        return "rgb(255,215,0)"
+    if address_mode:
+        return "cyan"
+    return "green"
 
 
 def _format_block_row(analysis: BlockAnalysis) -> tuple:
@@ -114,7 +141,7 @@ def scan_recent_blocks(path: dict, count: int | None = None) -> None:
         rich_error(str(exc))
         if exc.hint:
             console.print(f"    [dim]→ {exc.hint}[/]")
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError) as exc:
         show_error(str(exc))
 
     input("\n\aContinue...")
@@ -147,6 +174,7 @@ def show_mempool_glass(path: dict) -> None:
         summary.add_row("Analyzed txs", str(composition.analyzed_tx))
         summary.add_row("Template weight", f"{composition.analyzed_weight:,} / {composition.weight_limit:,}")
         summary.add_row("Fill", f"{composition.fill_pct:.1f}%")
+        summary.add_row("Source", composition.source)
 
         cats = Table(title="Transaction Categories", show_lines=True)
         cats.add_column("Category", style="bold")
@@ -172,20 +200,23 @@ def show_mempool_glass(path: dict) -> None:
         console.print()
         console.print(cats)
         console.print(
-            "\n[dim]Spam = BIP-110 violations, inscriptions, tokens, "
-            "oversized witness, or excess witness ratio[/]"
+            "\n[dim]Based on your node's current block template (Knots + BIP-110 policy). "
+            "Spam = BIP-110 violations, inscriptions, tokens, oversized witness.[/]"
+        )
+        console.print(
+            "[dim]Use [bold]D. Transaction Inspector[/] to drill into a specific txid.[/]"
         )
     except BitcoinCLIError as exc:
         rich_error(str(exc))
         if exc.hint:
             console.print(f"    [dim]→ {exc.hint}[/]")
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError) as exc:
         show_error(str(exc))
 
     input("\n\aContinue...")
 
 
-def _render_block_detail(analysis: BlockAnalysis) -> None:
+def _render_block_detail(analysis: BlockAnalysis) -> BlockAnalysis:
     sig = "YES" if analysis.bip110_signaling else "no"
     title = (
         f"Block #{analysis.height}  ·  Spam {analysis.spam_score}/100  ·  "
@@ -216,22 +247,65 @@ def _render_block_detail(analysis: BlockAnalysis) -> None:
 
     if not bad:
         console.print("[green]No problematic transactions detected.[/]")
-        return
+        return analysis
 
     tx_table = Table(title="Problematic Transactions (top 25)", show_lines=True)
+    tx_table.add_column("#", justify="right", style="dim")
     tx_table.add_column("TXID", style="red")
     tx_table.add_column("Weight", justify="right")
     tx_table.add_column("BIP-110 flags")
     tx_table.add_column("Signals")
 
-    for tx in bad[:25]:
+    for idx, tx in enumerate(bad[:25], start=1):
         flags = ", ".join(sorted(tx.bip110_flags)) or "—"
         signals = ", ".join(sorted(tx.signals)) or "—"
-        tx_table.add_row(tx.txid[:20] + "…", f"{tx.weight:,}", flags, signals)
+        tx_table.add_row(str(idx), tx.txid[:20] + "…", f"{tx.weight:,}", flags, signals)
 
     console.print(tx_table)
     if len(bad) > 25:
         console.print(f"[dim]… and {len(bad) - 25} more[/]")
+    return analysis
+
+
+def _prompt_tx_inspection_from_block(
+    path: dict,
+    analysis: BlockAnalysis,
+    bad_txs: list[TxAnalysis],
+) -> None:
+    if not bad_txs:
+        return
+
+    console.print()
+    choice = input(
+        "\033[1;32;40mInspect tx (# or full txid, Enter to skip): \033[0;37;40m"
+    ).strip()
+    if not choice:
+        return
+
+    tx_analysis: TxAnalysis | None = None
+    if choice.isdigit():
+        idx = int(choice)
+        if 1 <= idx <= min(len(bad_txs), 25):
+            tx_analysis = bad_txs[idx - 1]
+    else:
+        for tx in bad_txs:
+            if tx.txid.startswith(choice.lower()) or tx.txid == choice.lower():
+                tx_analysis = tx
+                break
+
+    if tx_analysis is None:
+        show_error("Transaction not found in this block's flagged list")
+        input("\n\aContinue...")
+        return
+
+    raw_tx = analysis.flagged_raw.get(tx_analysis.txid)
+    context = TxInspectContext(
+        block_hash=analysis.hash,
+        block_height=analysis.height,
+        raw_tx=raw_tx,
+        cached_analysis=tx_analysis,
+    )
+    show_tx_inspector(path, context=context, initial_query=tx_analysis.txid)
 
 
 def show_block_detail(path: dict, target: str | None = None) -> None:
@@ -257,14 +331,114 @@ def show_block_detail(path: dict, target: str | None = None) -> None:
         block = cli.get_block(block_hash, 2)
         analysis = analyze_block(block, spam_threshold=settings.spam_score_threshold)
         _render_block_detail(analysis)
+
+        bad_txs = [
+            tx for tx in analysis.transactions
+            if tx.has_bip110_violation or tx.is_spam_signal
+        ]
+        bad_txs.sort(key=lambda tx: tx.weight, reverse=True)
+        _prompt_tx_inspection_from_block(path, analysis, bad_txs)
     except BitcoinCLIError as exc:
         rich_error(str(exc))
         if exc.hint:
             console.print(f"    [dim]→ {exc.hint}[/]")
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError) as exc:
         show_error(str(exc))
 
     input("\n\aContinue...")
+
+
+def _render_tx_inspection(ins) -> None:
+    border = _inspection_border_style(
+        partial=ins.partial,
+        has_violation=ins.analysis.has_bip110_violation,
+        is_spam=ins.analysis.is_spam_signal,
+    )
+    console.print(
+        Panel(
+            Text.from_markup(format_inspection(ins)),
+            title="Transaction Inspector",
+            border_style=border,
+        )
+    )
+
+
+def _render_address_inspection(ins) -> None:
+    console.print(
+        Panel(
+            Text.from_markup(format_address_inspection(ins)),
+            title="Address Inspector",
+            border_style=_inspection_border_style(address_mode=True),
+        )
+    )
+
+
+def show_tx_inspector(
+    path: dict,
+    *,
+    context: TxInspectContext | None = None,
+    initial_query: str | None = None,
+) -> None:
+    """Interactive transaction and address inspector."""
+    settings = load_settings()
+    cli = _cli_for(path)
+    tx_service = TxService(cli, config=settings.inspector)
+    addr_service = AddressService(cli, config=settings.inspector)
+
+    while True:
+        clear()
+        _header()
+        console.print(
+            Panel(
+                Text.from_markup(
+                    "[bold]Transaction & Address Inspector[/]\n"
+                    "[dim]Enter a 64-char txid or Bitcoin address (bc1…, 1…, 3…)[/]\n"
+                    "[dim]All data verified locally — no third-party explorer[/]"
+                ),
+                border_style="cyan",
+            )
+        )
+        console.print()
+
+        query = initial_query
+        initial_query = None
+        if not query:
+            query = input(
+                "\033[1;32;40mQuery (txid or address, R to return): \033[0;37;40m"
+            ).strip()
+        if not query or query.upper() == "R":
+            return
+
+        try:
+            kind, value = classify_query(query)
+        except (ValueError, AddressQueryError) as exc:
+            rich_error(str(exc))
+            input("\n\aContinue...")
+            continue
+
+        try:
+            if kind == "txid":
+                ins = tx_service.inspect_txid(value, context=context)
+                _render_tx_inspection(ins)
+            else:
+                ins = addr_service.inspect_address(value)
+                _render_address_inspection(ins)
+        except TxQueryError as exc:
+            rich_error(str(exc))
+        except BitcoinCLIError as exc:
+            rich_error(str(exc))
+            if exc.hint:
+                console.print(f"    [dim]→ {exc.hint}[/]")
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            show_error(str(exc))
+
+        console.print()
+        follow = input(
+            "\033[1;32;40m[N] new query  [R] return to menu: \033[0;37;40m"
+        ).strip().upper()
+        if follow == "R":
+            return
+        context = None
 
 
 def launch_full_oraculovision(path: dict) -> None:
@@ -326,6 +500,8 @@ def run_oraclevision_menu(path: dict) -> None:
         elif choice in ("C",):
             show_block_detail(path)
         elif choice in ("D",):
+            show_tx_inspector(path)
+        elif choice in ("E",):
             launch_full_oraculovision(path)
         elif choice in ("R", ""):
             break

--- a/pybitblock/tests/oraclevision/test_addresses.py
+++ b/pybitblock/tests/oraclevision/test_addresses.py
@@ -1,0 +1,41 @@
+"""Tests for query classification."""
+
+from __future__ import annotations
+
+from oraclevision.addresses import AddressQueryError, classify_query, parse_address_query
+from oraclevision.tx_service import parse_tx_query
+
+
+def test_classify_txid() -> None:
+    txid = "ab" * 32
+    kind, value = classify_query(txid)
+    assert kind == "txid"
+    assert value == txid
+
+
+def test_classify_address() -> None:
+    addr = "bc1qtestaddressxxxxxxxxxxxxxxxxxxxxxx"
+    kind, value = classify_query(addr)
+    assert kind == "address"
+    assert value == addr
+
+
+def test_parse_tx_query_normalizes() -> None:
+    txid = "AB" * 32
+    assert parse_tx_query(txid) == txid.lower()
+
+
+def test_invalid_query_raises() -> None:
+    try:
+        classify_query("not-a-txid")
+        raise AssertionError("expected AddressQueryError")
+    except AddressQueryError:
+        pass
+
+
+def test_invalid_address_raises() -> None:
+    try:
+        parse_address_query("invalid-address")
+        raise AssertionError("expected AddressQueryError")
+    except AddressQueryError:
+        pass

--- a/pybitblock/tests/oraclevision/test_detectors.py
+++ b/pybitblock/tests/oraclevision/test_detectors.py
@@ -1,0 +1,31 @@
+"""Tests for pluggable transaction detectors."""
+
+from __future__ import annotations
+
+from oraclevision.bip110 import analyze_transaction
+from oraclevision.detectors import configure_detectors, run_detectors
+
+
+def test_builtin_detector_flags_large_op_return() -> None:
+    configure_detectors(["builtin"])
+    tx = {
+        "txid": "cc" * 32,
+        "weight": 400,
+        "vsize": 100,
+        "vin": [{"txid": "aa" * 32, "vout": 0, "scriptSig": {"hex": ""}}],
+        "vout": [
+            {
+                "value": 0,
+                "scriptPubKey": {
+                    "type": "nulldata",
+                    "hex": "6a" + "00" * 100,
+                    "asm": "OP_RETURN " + "00" * 100,
+                },
+            }
+        ],
+    }
+    result = run_detectors(tx)
+    assert "op_return" in result.signals
+
+    analysis = analyze_transaction(tx)
+    assert analysis.txid == "cc" * 32

--- a/pybitblock/tests/oraclevision/test_tx_flow.py
+++ b/pybitblock/tests/oraclevision/test_tx_flow.py
@@ -1,0 +1,83 @@
+"""Tests for transaction flow parsing."""
+
+from __future__ import annotations
+
+from oraclevision.tx_flow import build_flow_summary, parse_outputs
+
+
+def test_parse_outputs_with_addresses() -> None:
+    tx = {
+        "vin": [],
+        "vout": [
+            {
+                "n": 0,
+                "value": 0.5,
+                "scriptPubKey": {
+                    "type": "witness_v0_keyhash",
+                    "address": "bc1qrecipientxxxxxxxxxxxxxxxxxxxxxx",
+                },
+            },
+            {
+                "n": 1,
+                "value": 0.0499,
+                "scriptPubKey": {
+                    "type": "witness_v0_keyhash",
+                    "address": "bc1qchangexxxxxxxxxxxxxxxxxxxxxxxx",
+                },
+            },
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert len(flow.outputs) == 2
+    assert flow.total_output_btc == 0.5499
+    assert len(flow.recipients) == 2
+    assert flow.recipients[0].startswith("bc1q")
+
+
+def test_build_flow_with_prevouts_and_fee() -> None:
+    tx = {
+        "vin": [
+            {
+                "txid": "aa" * 32,
+                "vout": 0,
+                "prevout": {
+                    "value": 1.0,
+                    "scriptPubKey": {
+                        "type": "witness_v0_keyhash",
+                        "address": "bc1qsenderxxxxxxxxxxxxxxxxxxxxxxxx",
+                    },
+                },
+            }
+        ],
+        "vout": [
+            {
+                "n": 0,
+                "value": 0.9999,
+                "scriptPubKey": {
+                    "address": "bc1qoutxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                },
+            }
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert flow.inputs_resolved
+    assert flow.total_input_btc == 1.0
+    assert abs(flow.fee_btc - 0.0001) < 1e-8
+    assert flow.senders == ["bc1qsenderxxxxxxxxxxxxxxxxxxxxxxxx"]
+
+
+def test_partial_inputs_when_prevout_missing() -> None:
+    tx = {
+        "vin": [{"txid": "bb" * 32, "vout": 1}],
+        "vout": [
+            {
+                "n": 0,
+                "value": 0.1,
+                "scriptPubKey": {"address": "bc1qoutxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+            }
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert not flow.inputs_resolved
+    assert flow.inputs[0].label == "prevout unavailable"
+    assert flow.total_output_btc == 0.1


### PR DESCRIPTION
# OracleVision v2.2: Transaction Inspector & Pluggable Detectors

## Summary

This PR upgrades PyBLOCK's OracleVision integration from the initial v1 port to **v2.2 analysis parity**, adding deep transaction inspection, address lookup, pluggable BIP-110 detectors, and cross-menu drill-down from block analysis.

All features run locally via `bitcoin-cli` — **Don't Trust, Verify**.

## Motivation

The initial OracleVision integration (PR #738) gave PyBLOCK operators block scanning, Mempool Glass, and block detail views. The standalone [OracleVision](https://github.com/MarcanoFilms/oraculovision) project has since shipped **v2.2** with:

- **Transaction Inspector** — input/output flow, fees, BIP-110 flags, spam signals
- **Address Inspector** — UTXO balance via `scantxoutset`, mempool exposure
- **Pluggable detectors** — community-extensible BIP-110 rule checks
- **Pruned-node support** — partial inspection from block scan cache (`flagged_raw`)

This PR ports those analysis capabilities into PyBLOCK's Rich terminal UI so operators get v2.2 tooling without leaving the PyBLOCK menu.

## What's New

### Menu changes

| Option | Before | After |
|--------|--------|-------|
| A | BIP-110 Block Scanner | *(unchanged)* |
| B | Mempool Glass | *(unchanged, improved docs)* |
| C | Block Detail View | **+ drill-down to Transaction Inspector** |
| D | Launch Full TUI | **Transaction & Address Inspector** |
| E | — | Launch Full OracleVision TUI *(was D)* |

### New module: Transaction & Address Inspector (D)

Dual-mode inspector accepting a **64-char txid** or **Bitcoin address**:

**Transaction mode** shows:
- Mempool / confirmation status, block height, fees (BTC + sat/vB)
- Input/output flow with addresses, values, script types
- Mempool category (economic / spam / coinjoin / consolidation)
- BIP-110 compliance label and flag list
- Spam signals (inscription, brc20, runes, ordinals, op_return)

**Address mode** shows:
- Node validation, script type
- UTXO balance and count (`scantxoutset`, configurable timeout)
- Mempool exposure (capped scan of pending outputs)

**Pruned-node handling:**
- Block Detail caches flagged raw transactions during scan
- Inspector uses cached data when `getrawtransaction` is unavailable
- Partial view clearly labeled with yellow border

### Pluggable detectors (`pybitblock/oraclevision/detectors/`)

Refactored `bip110.py` to delegate per-transaction analysis to a detector registry:

| File | Purpose |
|------|---------|
| `detectors/__init__.py` | Registry API: `register()`, `run_detectors()`, `configure_detectors()` |
| `detectors/builtin.py` | Default Knots BIP-110 + spam heuristics (extracted from monolithic bip110) |

Community PRs can add new detectors without touching UI code. Enable via `detectors_enabled` in config.

### New supporting modules

| File | Purpose |
|------|---------|
| `tx_flow.py` | Pure I/O parsing: inputs, outputs, fees, senders/recipients |
| `tx_service.py` | Fetch, enrich, and format transaction inspections |
| `address_service.py` | Address validation, UTXO scan, mempool exposure |
| `addresses.py` | Query classification (txid vs address) |
| `markup.py` | Safe Rich markup escaping for node-sourced text |

### Extended `bitcoin_cli.py`

New RPC wrappers for the inspector:
- `getrawmempool(verbose)`
- `getrawtransaction(txid, verbose, block_hash=…)` — pruned-node compatible
- `getblockchaininfo()`
- `validateaddress(address)`
- `scantxoutset_address(address, timeout=…)`

### Block analysis improvements

- `BlockAnalysis.flagged_raw` — caches raw tx dicts for flagged transactions
- Block Detail prompts for tx drill-down after showing problematic transactions
- Mempool Glass notes link to Transaction Inspector

## Configuration

New keys in `oraclevision.conf`:

| Setting | Default | Description |
|---------|---------|-------------|
| `max_vin_lookups` | 4 | Parent tx RPC lookups to resolve missing prevouts |
| `scantxoutset_timeout` | 90 | Seconds for UTXO scan (address mode) |
| `mempool_scan_limit` | 30 | Max mempool txs scanned for address exposure |
| `detectors_enabled` | `["builtin"]` | Active detector plugins |

## Design Principles

- **Zero extra dependencies** — Rich UI + bitcoin-cli only (same as PyBLOCK)
- **Modular analysis** — detectors, tx_flow, services separated from terminal UI
- **Upstream alignment** — ported from OracleVision v2.2 analysis layer
- **Full TUI still external** — option E launches standalone Textual dashboard

## Relationship to Standalone OracleVision

| Feature | PyBLOCK built-in | Full OracleVision TUI |
|---------|------------------|----------------------|
| Block scanner | Yes | Yes (+ live charts) |
| Mempool Glass | Yes | Yes (+ dedicated screen) |
| Tx Inspector | Yes (Rich terminal) | Yes (Textual, keyboard nav) |
| Address Inspector | Yes (UTXO + mempool) | Yes (+ history export) |
| DATUM mining panel | No | Yes |
| Ocean account stats | No | Yes |
| Multi-screen navigation | No | Yes |

Operators who want the full dashboard install OracleVision separately and use **E. Launch Full OracleVision TUI**.

## Testing

```bash
cd pybitblock

# Import check
python3 -c "from oraclevision.tx_service import TxService; print('ok')"

# Unit tests
python3 -m pytest tests/oraclevision/ -v

# Manual test path
python3 PyBlock.py
# → B. Bitcoin → OV. OracleVision
#   → D. Transaction & Address Inspector (paste a txid)
#   → C. Block Detail View → inspect flagged tx
```

### Node requirements

- Synced Knots/Core with RPC enabled
- `getblock` verbosity 2 (block scanner, block detail)
- `getblocktemplate` with mining RPC (Mempool Glass)
- `getrawtransaction` with optional `blockhash` (tx inspector)
- `scantxoutset` (address mode — can take up to 90s on large UTXO sets)

## Files Changed

### New
- `pybitblock/oraclevision/detectors/__init__.py`
- `pybitblock/oraclevision/detectors/builtin.py`
- `pybitblock/oraclevision/tx_flow.py`
- `pybitblock/oraclevision/tx_service.py`
- `pybitblock/oraclevision/address_service.py`
- `pybitblock/oraclevision/addresses.py`
- `pybitblock/oraclevision/markup.py`
- `pybitblock/tests/oraclevision/test_tx_flow.py`
- `pybitblock/tests/oraclevision/test_detectors.py`
- `pybitblock/tests/oraclevision/test_addresses.py`
- `PR_ORACLEVISION_V2.2.md`

### Modified
- `pybitblock/oraclevision/bip110.py` — detector architecture + `flagged_raw`
- `pybitblock/oraclevision/bitcoin_cli.py` — tx/address RPC methods
- `pybitblock/oraclevision/config.py` — inspector settings + detector config
- `pybitblock/oraclevision/ui.py` — menu D/E, tx inspector, block drill-down
- `pybitblock/oraclevision/__init__.py` — new exports
- `pybitblock/oraclevision/mempool_compose.py` — legacy aliases
- `pybitblock/config/oraclevision.conf.example`
- `README.md`

## Upstream

Analysis logic ported from [MarcanoFilms/oraculovision](https://github.com/MarcanoFilms/oraculovision) v2.2.0a1.

## Summary by Sourcery

Add a local Transaction & Address Inspector with drill-down from block analysis and upgrade OracleVision integration to use pluggable BIP-110 detectors and new RPC-backed services.

New Features:
- Introduce an interactive Transaction & Address Inspector accessible from the OracleVision menu.
- Enable drill-down from Block Detail View and Mempool Glass into transaction-level inspection.
- Add RPC-backed services for transaction flow parsing, address inspection, and richer oraclevision exports.

Enhancements:
- Refactor BIP-110 analysis to use a pluggable detector registry with a builtin detector module.
- Cache raw flagged transactions during block analysis to support partial inspection on pruned nodes.
- Extend OracleVision configuration with inspector tuning and detector enablement options.
- Expose additional bitcoin-cli RPC helpers for mempool, transaction, blockchain, and UTXO scanning.

Documentation:
- Document the new OracleVision inspector features, configuration keys, and detector architecture, including a dedicated PR_ORACLEVISION_V2.2 overview file.

Tests:
- Add tests for transaction flow parsing, detector behavior, and address/txid query classification.