### PR TITLE
fix: OracleVision v2.2 review follow-up (Sourcery feedback)

### DIFF
--- a/PR_ORACLEVISION_V2.2.md
+++ b/PR_ORACLEVISION_V2.2.md
@@ -92,7 +92,7 @@ New keys in `oraclevision.conf`:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `max_vin_lookups` | 4 | Parent tx RPC lookups to resolve missing prevouts |
+| `max_vin_lookups` | 4 | Parent transaction RPC lookups to resolve missing prevouts |
 | `scantxoutset_timeout` | 90 | Seconds for UTXO scan (address mode) |
 | `mempool_scan_limit` | 30 | Max mempool txs scanned for address exposure |
 | `detectors_enabled` | `["builtin"]` | Active detector plugins |

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ cp pybitblock/config/oraclevision.conf.example pybitblock/config/oraclevision.co
 | `spam_score_threshold` | 45 | Score above this marks a block as VIOLATION |
 | `bitcoin_datadir` | `""` | Optional `-datadir` for bitcoin-cli |
 | `oraculovision_command` | `oraculovision` | Command to launch the full TUI |
-| `max_vin_lookups` | 4 | Parent-tx RPC lookups to resolve input prevouts in Transaction Inspector |
+| `max_vin_lookups` | 4 | Parent transaction RPC lookups to resolve input prevouts in Transaction Inspector |
 | `scantxoutset_timeout` | 90 | Seconds allowed for UTXO scan in Address Inspector |
 | `mempool_scan_limit` | 30 | Max mempool txs scanned for address mempool exposure |
 | `detectors_enabled` | `["builtin"]` | Active BIP-110/spam detector plugins |

--- a/pybitblock/oraclevision/address_service.py
+++ b/pybitblock/oraclevision/address_service.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-from oraclevision.addresses import parse_address_query
+from oraclevision.addresses import parse_address_query, script_type_from_validation
 from oraclevision.bitcoin_cli import BitcoinCLI, BitcoinCLIError
 from oraclevision.config import InspectorConfig
 
@@ -81,15 +81,16 @@ class AddressService:
             return result
 
         result.valid = bool(validation.get("isvalid"))
-        spk = validation.get("scriptPubKey")
-        if isinstance(spk, dict):
-            result.script_type = str(spk.get("type", "") or "")
-        elif validation.get("iswitness"):
-            result.script_type = "witness"
-        elif validation.get("isscript"):
-            result.script_type = "script"
-        else:
-            result.script_type = ""
+        result.script_type = script_type_from_validation(validation)
+
+        if result.valid and not result.script_type:
+            try:
+                info = self.cli.get_address_info(address)
+                spk = info.get("scriptPubKey") or {}
+                if isinstance(spk, dict) and spk.get("type"):
+                    result.script_type = str(spk["type"])
+            except BitcoinCLIError:
+                pass
 
         if not result.valid:
             result.error = "Address failed node validation"

--- a/pybitblock/oraclevision/addresses.py
+++ b/pybitblock/oraclevision/addresses.py
@@ -37,3 +37,30 @@ def classify_query(raw: str) -> tuple[str, str]:
     if is_txid_query(text):
         return "txid", text.lower()
     return "address", parse_address_query(text)
+
+
+def script_type_from_validation(validation: dict) -> str:
+    """Derive a display script type from validateaddress output.
+
+    Core returns ``scriptPubKey`` as a hex string, not a decoded object.
+    Use witness/script flags when the verbose type is unavailable.
+    """
+    spk = validation.get("scriptPubKey")
+    if isinstance(spk, dict):
+        return str(spk.get("type", "") or "")
+
+    if validation.get("iswitness"):
+        witness_version = validation.get("witness_version")
+        if witness_version == 1:
+            return "witness_v1_taproot"
+        if witness_version == 0:
+            return "witness_v0_keyhash"
+        return "witness"
+
+    if validation.get("isscript"):
+        return "scripthash"
+
+    if validation.get("isvalid"):
+        return "pubkeyhash"
+
+    return ""

--- a/pybitblock/oraclevision/bitcoin_cli.py
+++ b/pybitblock/oraclevision/bitcoin_cli.py
@@ -139,7 +139,12 @@ class BitcoinCLI:
         return self.call("getblockchaininfo")
 
     def validate_address(self, address: str) -> dict[str, Any]:
-        return self.call("validateaddress", address)
+        result = self.call("validateaddress", address)
+        return result if isinstance(result, dict) else {}
+
+    def get_address_info(self, address: str) -> dict[str, Any]:
+        result = self.call("getaddressinfo", address)
+        return result if isinstance(result, dict) else {}
 
     def scantxoutset_address(
         self,
@@ -152,7 +157,8 @@ class BitcoinCLI:
         if timeout is not None:
             self.timeout = timeout
         try:
-            return self.call("scantxoutset", "start", [f"addr({address})"])
+            result = self.call("scantxoutset", "start", [f"addr({address})"])
+            return result if isinstance(result, dict) else {}
         finally:
             self.timeout = original_timeout
 

--- a/pybitblock/oraclevision/detectors/__init__.py
+++ b/pybitblock/oraclevision/detectors/__init__.py
@@ -42,6 +42,11 @@ def enabled_detectors() -> tuple[str, ...]:
 
 
 def run_detectors(tx: dict[str, Any], *, enabled: tuple[str, ...] | None = None) -> DetectorResult:
+    """Run enabled detectors and merge their results.
+
+    ``witness_bytes`` uses max() because each detector must report the full
+    transaction witness size, not a per-input partial measurement.
+    """
     names = enabled or _ACTIVE
     combined = DetectorResult()
     for name in names:
@@ -68,7 +73,10 @@ def configure_detectors(enabled: list[str] | None = None) -> None:
     if enabled:
         for name in enabled:
             if name == "example_dust":
-                from oraclevision.detectors.example_dust import DustDetector
+                try:
+                    from oraclevision.detectors.example_dust import DustDetector
 
-                register(DustDetector())
+                    register(DustDetector())
+                except ImportError:
+                    pass
     set_enabled(enabled)

--- a/pybitblock/oraclevision/tx_service.py
+++ b/pybitblock/oraclevision/tx_service.py
@@ -241,7 +241,6 @@ class TxService:
         if ctx.block_hash:
             attempts.append((ctx.block_hash, "getrawtransaction + blockhash"))
 
-        last_exc: BitcoinCLIError | None = None
         for block_hash, label in attempts:
             try:
                 tx = self.cli.get_raw_transaction(
@@ -254,11 +253,9 @@ class TxService:
                     if block_hash and label.endswith("blockhash"):
                         note += " (pruned-node compatible)"
                     return tx, note
-            except BitcoinCLIError as exc:
-                last_exc = exc
+            except BitcoinCLIError:
+                continue
 
-        if last_exc:
-            _ = last_exc
         return None, None
 
     def _partial_inspection(

--- a/pybitblock/oraclevision/ui.py
+++ b/pybitblock/oraclevision/ui.py
@@ -216,6 +216,16 @@ def show_mempool_glass(path: dict) -> None:
     input("\n\aContinue...")
 
 
+def _get_flagged_transactions(analysis: BlockAnalysis) -> list[TxAnalysis]:
+    """Return problematic transactions sorted by weight (heaviest first)."""
+    bad_txs = [
+        tx for tx in analysis.transactions
+        if tx.has_bip110_violation or tx.is_spam_signal
+    ]
+    bad_txs.sort(key=lambda tx: tx.weight, reverse=True)
+    return bad_txs
+
+
 def _render_block_detail(analysis: BlockAnalysis) -> BlockAnalysis:
     sig = "YES" if analysis.bip110_signaling else "no"
     title = (
@@ -242,8 +252,7 @@ def _render_block_detail(analysis: BlockAnalysis) -> BlockAnalysis:
     console.print(info)
     console.print()
 
-    bad = [tx for tx in analysis.transactions if tx.has_bip110_violation or tx.is_spam_signal]
-    bad.sort(key=lambda tx: tx.weight, reverse=True)
+    bad = _get_flagged_transactions(analysis)
 
     if not bad:
         console.print("[green]No problematic transactions detected.[/]")
@@ -331,13 +340,7 @@ def show_block_detail(path: dict, target: str | None = None) -> None:
         block = cli.get_block(block_hash, 2)
         analysis = analyze_block(block, spam_threshold=settings.spam_score_threshold)
         _render_block_detail(analysis)
-
-        bad_txs = [
-            tx for tx in analysis.transactions
-            if tx.has_bip110_violation or tx.is_spam_signal
-        ]
-        bad_txs.sort(key=lambda tx: tx.weight, reverse=True)
-        _prompt_tx_inspection_from_block(path, analysis, bad_txs)
+        _prompt_tx_inspection_from_block(path, analysis, _get_flagged_transactions(analysis))
     except BitcoinCLIError as exc:
         rich_error(str(exc))
         if exc.hint:

--- a/pybitblock/tests/oraclevision/test_addresses.py
+++ b/pybitblock/tests/oraclevision/test_addresses.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from oraclevision.addresses import AddressQueryError, classify_query, parse_address_query
+from oraclevision.addresses import (
+    AddressQueryError,
+    classify_query,
+    is_txid_query,
+    parse_address_query,
+    script_type_from_validation,
+)
 from oraclevision.tx_service import parse_tx_query
 
 
@@ -13,16 +19,40 @@ def test_classify_txid() -> None:
     assert value == txid
 
 
-def test_classify_address() -> None:
+def test_classify_address_bech32() -> None:
     addr = "bc1qtestaddressxxxxxxxxxxxxxxxxxxxxxx"
     kind, value = classify_query(addr)
     assert kind == "address"
     assert value == addr
 
 
+def test_parse_address_query_p2pkh() -> None:
+    addr = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
+    assert parse_address_query(addr) == addr
+
+
+def test_parse_address_query_p2sh() -> None:
+    addr = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
+    assert parse_address_query(addr) == addr
+
+
 def test_parse_tx_query_normalizes() -> None:
     txid = "AB" * 32
     assert parse_tx_query(txid) == txid.lower()
+
+
+def test_is_txid_query() -> None:
+    valid = "ab" * 32
+    assert is_txid_query(valid) is True
+    assert is_txid_query("ab" * 31) is False
+
+
+def test_classify_query_empty_raises() -> None:
+    try:
+        classify_query("")
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass
 
 
 def test_invalid_query_raises() -> None:
@@ -39,3 +69,23 @@ def test_invalid_address_raises() -> None:
         raise AssertionError("expected AddressQueryError")
     except AddressQueryError:
         pass
+
+
+def test_script_type_from_validation_witness_v0() -> None:
+    result = script_type_from_validation({
+        "isvalid": True,
+        "iswitness": True,
+        "witness_version": 0,
+        "scriptPubKey": "0014abcd",
+    })
+    assert result == "witness_v0_keyhash"
+
+
+def test_script_type_from_validation_taproot() -> None:
+    result = script_type_from_validation({
+        "isvalid": True,
+        "iswitness": True,
+        "witness_version": 1,
+        "scriptPubKey": "5120abcd",
+    })
+    assert result == "witness_v1_taproot"

--- a/pybitblock/tests/oraclevision/test_detectors.py
+++ b/pybitblock/tests/oraclevision/test_detectors.py
@@ -3,7 +3,21 @@
 from __future__ import annotations
 
 from oraclevision.bip110 import analyze_transaction
-from oraclevision.detectors import configure_detectors, run_detectors
+from oraclevision.detectors import (
+    DetectorResult,
+    configure_detectors,
+    enabled_detectors,
+    register,
+    run_detectors,
+)
+from oraclevision.detectors.builtin import BuiltinDetector
+
+
+class _SignalDetector:
+    name = "signal_only"
+
+    def detect(self, tx: dict) -> DetectorResult:
+        return DetectorResult(signals={"custom"}, witness_bytes=10)
 
 
 def test_builtin_detector_flags_large_op_return() -> None:
@@ -29,3 +43,26 @@ def test_builtin_detector_flags_large_op_return() -> None:
 
     analysis = analyze_transaction(tx)
     assert analysis.txid == "cc" * 32
+    assert analysis.witness_bytes >= 0
+
+
+def test_configure_detectors_ignores_unknown() -> None:
+    configure_detectors(["builtin", "missing_detector"])
+    assert enabled_detectors() == ("builtin", "missing_detector")
+
+
+def test_run_detectors_merges_multiple_detectors() -> None:
+    register(BuiltinDetector())
+    register(_SignalDetector())
+    configure_detectors(["builtin", "signal_only"])
+
+    tx = {
+        "txid": "dd" * 32,
+        "weight": 200,
+        "vsize": 50,
+        "vin": [{"txid": "aa" * 32, "vout": 0, "scriptSig": {"hex": ""}}],
+        "vout": [{"value": 1.0, "scriptPubKey": {"type": "pubkeyhash", "hex": "76a91400"}}],
+    }
+    result = run_detectors(tx)
+    assert "custom" in result.signals
+    assert result.witness_bytes >= 10

--- a/pybitblock/tests/oraclevision/test_tx_flow.py
+++ b/pybitblock/tests/oraclevision/test_tx_flow.py
@@ -66,6 +66,112 @@ def test_build_flow_with_prevouts_and_fee() -> None:
     assert flow.senders == ["bc1qsenderxxxxxxxxxxxxxxxxxxxxxxxx"]
 
 
+def test_coinbase_input_ignored_in_fee() -> None:
+    tx = {
+        "vin": [{"coinbase": "00"}],
+        "vout": [
+            {
+                "n": 0,
+                "value": 50.0,
+                "scriptPubKey": {"address": "bc1qcoinbasexxxxxxxxxxxxxxxxxxxxxxx"},
+            }
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert flow.inputs[0].label == "coinbase"
+    assert flow.fee_btc is None
+
+
+def test_mixed_prevouts_partial_inputs() -> None:
+    tx = {
+        "vin": [
+            {
+                "txid": "aa" * 32,
+                "vout": 0,
+                "prevout": {
+                    "value": 1.0,
+                    "scriptPubKey": {"address": "bc1qknownxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+                },
+            },
+            {"txid": "bb" * 32, "vout": 1},
+        ],
+        "vout": [
+            {
+                "n": 0,
+                "value": 0.9999,
+                "scriptPubKey": {"address": "bc1qoutxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+            }
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert not flow.inputs_resolved
+    assert flow.inputs_partial
+    assert flow.total_input_btc == 1.0
+    assert flow.fee_btc is None
+
+
+def test_op_return_excluded_from_output_total() -> None:
+    tx = {
+        "vin": [],
+        "vout": [
+            {
+                "n": 0,
+                "value": 0.0,
+                "scriptPubKey": {"type": "nulldata", "asm": "OP_RETURN 48656c6c6f"},
+            },
+            {
+                "n": 1,
+                "value": 0.5,
+                "scriptPubKey": {"address": "bc1qrecipientxxxxxxxxxxxxxxxxxxxxxx"},
+            },
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert flow.outputs[0].label == "OP_RETURN"
+    assert flow.total_output_btc == 0.5
+
+
+def test_all_addresses_deduped_and_ordered() -> None:
+    tx = {
+        "vin": [
+            {
+                "txid": "aa" * 32,
+                "vout": 0,
+                "prevout": {
+                    "value": 1.0,
+                    "scriptPubKey": {"address": "bc1qaddr1xxxxxxxxxxxxxxxxxxxxxxxxxx"},
+                },
+            },
+            {
+                "txid": "bb" * 32,
+                "vout": 1,
+                "prevout": {
+                    "value": 0.5,
+                    "scriptPubKey": {"address": "bc1qaddr2xxxxxxxxxxxxxxxxxxxxxxxxxx"},
+                },
+            },
+        ],
+        "vout": [
+            {
+                "n": 0,
+                "value": 0.4,
+                "scriptPubKey": {"address": "bc1qaddr1xxxxxxxxxxxxxxxxxxxxxxxxxx"},
+            },
+            {
+                "n": 1,
+                "value": 0.6,
+                "scriptPubKey": {"address": "bc1qaddr3xxxxxxxxxxxxxxxxxxxxxxxxxx"},
+            },
+        ],
+    }
+    flow = build_flow_summary(tx)
+    assert flow.all_addresses == [
+        "bc1qaddr1xxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "bc1qaddr2xxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "bc1qaddr3xxxxxxxxxxxxxxxxxxxxxxxxxx",
+    ]
+
+
 def test_partial_inputs_when_prevout_missing() -> None:
     tx = {
         "vin": [{"txid": "bb" * 32, "vout": 1}],


### PR DESCRIPTION
Follow-up to #739 — addresses Sourcery review feedback that landed after the merge.

## Changes

- **`script_type_from_validation()`** — Core returns `scriptPubKey` as hex, not a decoded object; derive witness/taproot/P2PKH types from validation flags
- **`getaddressinfo` fallback** — when `validateaddress` does not expose script type
- **Safer RPC guards** — `validateaddress`, `getaddressinfo`, `scantxoutset` return `{}` on unexpected responses
- **`_get_flagged_transactions()`** — deduplicate flagged-tx selection in `ui.py`
- **`configure_detectors`** — optional `example_dust` import wrapped in try/except
- **`tx_service`** — remove dead `last_exc` handling
- **Tests** — 21 unit tests (addresses, tx_flow, detectors)

## Testing

```
cd pybitblock && python3 -c "… manual test runner …"
# All 21 tests passed
```

No new dependencies. No menu or config schema changes.

## Summary by Sourcery

Tighten OracleVision v2.2 address/transaction analysis and detector handling based on post-merge review feedback.

Bug Fixes:
- Ensure address script types are correctly derived from validateaddress output and fall back to getaddressinfo when needed.
- Harden Bitcoin Core RPC wrappers so validateaddress, getaddressinfo, and scantxoutset safely handle unexpected non-dict responses.
- Avoid miscounting transaction fees and outputs by ignoring coinbase inputs and OP_RETURN outputs in flow summaries, and handling partially resolved prevouts.

Enhancements:
- Refactor flagged-transaction selection into a shared helper for block detail views to keep BIP-110 and spam inspection consistent.
- Improve detector configuration and execution to merge results across multiple detectors, tolerate unknown entries, and optionally load example_dust only when available.
- Simplify transaction service raw-tx lookup error handling by removing unused exception tracking.

Documentation:
- Clarify configuration documentation wording around max_vin_lookups in the OracleVision PR notes and README.
- Document detector result aggregation semantics in the run_detectors docstring.

Tests:
- Add address parsing and classification tests for multiple address types and error conditions, including script type derivation from validation data.
- Extend transaction flow tests to cover coinbase fee handling, OP_RETURN exclusion, mixed/partial prevouts, and address deduplication ordering.
- Add detector tests to verify builtin behavior, multi-detector result merging, enabled-detector configuration, and analysis witness-bytes reporting.